### PR TITLE
Add Kuzu Explorer integration for graph visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ Expected output: All systems validated ✅
 python bootstrap/scripts/load_articles.py --count 10
 ```
 
+### Explore the Graph
+
+Visualize your knowledge graph interactively using [Kuzu Explorer](https://github.com/kuzudb/explorer),
+a browser-based UI that runs via Docker.
+
+```bash
+# Launch interactive graph explorer (requires Docker)
+python bootstrap/scripts/explore.py --db data/wikigr_1k.db
+# Opens browser at http://localhost:8000
+```
+
+Or use the installed entry point:
+
+```bash
+wikigr-explore --db data/wikigr_1k.db --port 8000
+```
+
 ## Project Structure
 
 ```

--- a/bootstrap/scripts/explore.py
+++ b/bootstrap/scripts/explore.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Launch Kuzu Explorer for interactive graph visualization.
+
+Kuzu Explorer is a browser-based UI for exploring graph databases.
+It runs as a Docker container (kuzudb/explorer) and mounts the local
+database directory as a volume.
+
+Usage:
+    python bootstrap/scripts/explore.py [--db data/wikigr_1k.db] [--port 8000]
+
+Requirements:
+    Docker must be installed and running.
+"""
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+DOCKER_IMAGE = "kuzudb/explorer:latest"
+
+
+def _check_docker() -> str:
+    """Return the path to docker (or podman), or exit with an error."""
+    for cmd in ("docker", "podman"):
+        path = shutil.which(cmd)
+        if path is not None:
+            return path
+    print("Error: Neither docker nor podman found in PATH.")
+    print("Install Docker: https://docs.docker.com/get-docker/")
+    sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Launch Kuzu Explorer for interactive graph visualization"
+    )
+    parser.add_argument(
+        "--db",
+        default="data/wikigr_1k.db",
+        help="Path to Kuzu database directory (default: data/wikigr_1k.db)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port to serve on (default: 8000)",
+    )
+    args = parser.parse_args()
+
+    db_path = Path(args.db).resolve()
+    if not db_path.exists():
+        print(f"Database not found: {db_path}")
+        print("Run the expansion pipeline first to create a database:")
+        print("  python bootstrap/quickstart.py")
+        sys.exit(1)
+
+    docker = _check_docker()
+
+    # Pull the image if not already present
+    print(f"Ensuring {DOCKER_IMAGE} is available...")
+    pull_result = subprocess.run(
+        [docker, "image", "inspect", DOCKER_IMAGE],
+        capture_output=True,
+    )
+    if pull_result.returncode != 0:
+        print(f"Pulling {DOCKER_IMAGE}...")
+        subprocess.run([docker, "pull", DOCKER_IMAGE], check=True)
+
+    print(f"Launching Kuzu Explorer on http://localhost:{args.port}")
+    print(f"Database: {db_path}")
+    print("Press Ctrl+C to stop.")
+    print()
+
+    container_name = "wikigr-explorer"
+
+    # Stop any existing container with the same name
+    subprocess.run(
+        [docker, "rm", "-f", container_name],
+        capture_output=True,
+    )
+
+    cmd = [
+        docker,
+        "run",
+        "--name",
+        container_name,
+        "-p",
+        f"{args.port}:8000",
+        "-v",
+        f"{db_path}:/database",
+        "-e",
+        "MODE=READ_ONLY",
+        "--rm",
+        DOCKER_IMAGE,
+    ]
+
+    # Add Podman-specific flag for volume permissions
+    if "podman" in docker:
+        cmd.insert(-1, "--userns=keep-id")
+
+    try:
+        subprocess.run(cmd, check=True)
+    except KeyboardInterrupt:
+        print("\nKuzu Explorer stopped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ test = [
 [project.scripts]
 wikigr-monitor = "bootstrap.scripts.monitor_expansion:main"
 wikigr-schema = "bootstrap.schema.ryugraph_schema:main"
+wikigr-explore = "bootstrap.scripts.explore:main"
 
 [project.urls]
 Homepage = "https://github.com/rysweet/wikigr"


### PR DESCRIPTION
## Summary

Adds a launch script for Kuzu Explorer, the official graph visualization tool for Kuzu databases. Uses Docker (the only distribution method for Kuzu Explorer).

## Changes

- **New:** `bootstrap/scripts/explore.py` - Launch script with `--db` and `--port` args
- **Modified:** `pyproject.toml` - Added `wikigr-explore` entry point
- **Modified:** `README.md` - Added "Explore the Graph" section

## Usage

```bash
# Launch explorer on the 1K database
python bootstrap/scripts/explore.py --db data/wikigr_1k.db

# Or via entry point
wikigr-explore --db data/wikigr_1k.db
```

Opens browser at http://localhost:8000 with interactive graph explorer.

**Requires:** Docker or Podman installed.

## Test Plan

- [x] Script validates database exists before launch
- [x] Script checks for Docker/Podman availability
- [x] Graceful Ctrl+C shutdown
- [x] Pre-commit hooks pass

Closes: N/A (enhancement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)