### PR TITLE
Extend CI lint and banned-pattern checks to cover backend/

### DIFF
--- a/.github/scripts/check-banned-patterns.sh
+++ b/.github/scripts/check-banned-patterns.sh
@@ -10,7 +10,7 @@ echo "=== Banned Pattern Scanner ==="
 echo ""
 echo "--- Check 1: TODO/FIXME/HACK/PLACEHOLDER in source code ---"
 matches=$(git grep -nE '(TODO|FIXME|HACK|PLACEHOLDER|XXX)' \
-  -- 'bootstrap/src/**/*.py' ':!bootstrap/src/*/tests/*' 2>/dev/null || true)
+  -- 'bootstrap/src/**/*.py' 'backend/**/*.py' ':!bootstrap/src/*/tests/*' ':!backend/tests/*' 2>/dev/null || true)
 if [ -n "$matches" ]; then
   echo "ERROR: Found banned markers in source code:"
   echo "$matches"
@@ -34,7 +34,7 @@ fi
 # 3. Swallowed exceptions: bare except or except Exception: pass
 echo ""
 echo "--- Check 3: Swallowed exceptions ---"
-bare=$(git grep -nP '^\s*except\s*:' -- 'bootstrap/src/**/*.py' 2>/dev/null || true)
+bare=$(git grep -nP '^\s*except\s*:' -- 'bootstrap/src/**/*.py' 'backend/**/*.py' ':!backend/tests/*' 2>/dev/null || true)
 if [ -n "$bare" ]; then
   echo "ERROR: Bare except: found:"
   echo "$bare"
@@ -45,7 +45,7 @@ fi
 
 # Also check for except Exception: pass pattern
 swallowed=$(git grep -nP -A1 'except\s+(Exception|BaseException)' \
-  -- 'bootstrap/src/**/*.py' ':!bootstrap/src/*/tests/*' 2>/dev/null | \
+  -- 'bootstrap/src/**/*.py' 'backend/**/*.py' ':!bootstrap/src/*/tests/*' ':!backend/tests/*' 2>/dev/null | \
   grep -B1 '^\s*pass\s*$' || true)
 if [ -n "$swallowed" ]; then
   echo "WARNING: Potential swallowed exceptions found"
@@ -56,7 +56,7 @@ fi
 echo ""
 echo "--- Check 4: Debug artifacts ---"
 matches=$(git grep -nE '(breakpoint\(\)|import\s+pdb|pdb\.set_trace)' \
-  -- 'bootstrap/src/**/*.py' ':!bootstrap/src/*/tests/*' 2>/dev/null || true)
+  -- 'bootstrap/src/**/*.py' 'backend/**/*.py' ':!bootstrap/src/*/tests/*' ':!backend/tests/*' 2>/dev/null || true)
 if [ -n "$matches" ]; then
   echo "ERROR: Debug artifacts found:"
   echo "$matches"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
       - run: uv python install ${{ env.PYTHON_VERSION }}
       - run: uv pip install --system -e ".[dev]"
       - name: Check formatting
-        run: ruff format --check bootstrap/
+        run: ruff format --check bootstrap/ backend/
       - name: Lint
-        run: ruff check bootstrap/
+        run: ruff check bootstrap/ backend/
       - name: Type check
-        run: pyright bootstrap/src bootstrap/schema
+        run: pyright bootstrap/src bootstrap/schema backend/
 
   test:
     name: Test Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ indent-style = "space"
 line-ending = "auto"
 
 [tool.pyright]
-include = ["bootstrap/src", "bootstrap/schema", "bootstrap/scripts"]
+include = ["bootstrap/src", "bootstrap/schema", "bootstrap/scripts", "backend"]
 exclude = [
     "**/__pycache__",
     "**/node_modules",

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -2,7 +2,8 @@
   "include": [
     "bootstrap/src",
     "bootstrap/schema",
-    "bootstrap/scripts"
+    "bootstrap/scripts",
+    "backend"
   ],
   "exclude": [
     "**/__pycache__",
@@ -35,6 +36,11 @@
   "executionEnvironments": [
     {
       "root": "bootstrap/src",
+      "pythonVersion": "3.10",
+      "extraPaths": []
+    },
+    {
+      "root": "backend",
       "pythonVersion": "3.10",
       "extraPaths": []
     }


### PR DESCRIPTION
## Summary
- Add `backend/` to ruff format, ruff check, and pyright in the CI lint job (`.github/workflows/ci.yml`)
- Extend all 4 grep patterns in `.github/scripts/check-banned-patterns.sh` to scan `backend/**/*.py` (with test exclusions)
- Add `backend` to pyright include paths in both `pyproject.toml` and `pyrightconfig.json`

Fixes #16

## Test plan
- [ ] CI lint job runs ruff and pyright against both `bootstrap/` and `backend/`
- [ ] Banned-pattern scanner catches TODO/FIXME/debug artifacts in `backend/` source files
- [ ] Backend test files (`backend/tests/*`) are properly excluded from banned-pattern scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)