### PR TITLE
Fix loky semaphore leak in expansion script

### DIFF
--- a/scripts/run_30k_expansion.py
+++ b/scripts/run_30k_expansion.py
@@ -16,6 +16,13 @@ import sys
 import time
 from pathlib import Path
 
+# Prevent loky/tokenizers semaphore leak that crashes long-running processes.
+# sentence-transformers uses joblib/loky for parallel tokenization, which
+# leaks semaphores over thousands of encode() calls, eventually triggering
+# a resource_tracker crash after ~6K articles.
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+os.environ["LOKY_MAX_CPU_COUNT"] = "1"
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from bootstrap.src.expansion.orchestrator import RyuGraphOrchestrator


### PR DESCRIPTION
## Summary
Set `TOKENIZERS_PARALLELISM=false` and `LOKY_MAX_CPU_COUNT=1` before importing sentence-transformers. Fixes the resource_tracker semaphore leak that crashed the 30K expansion every ~6K articles.

**Before**: 67% memory usage, crashes with `resource_tracker: There appear to be 1 leaked semaphore objects`
**After**: <8% memory, runs continuously

Partially addresses #3