### PR TITLE
Fix all 9 quality audit issues

### DIFF
--- a/backend/api/v1/articles.py
+++ b/backend/api/v1/articles.py
@@ -32,7 +32,7 @@ router = APIRouter(prefix="/api/v1", tags=["articles"])
     },
 )
 @limiter.limit("30/minute")
-async def get_article(
+def get_article(
     request: Request,  # noqa: ARG001 - required by slowapi limiter
     response: Response,
     title: str = Path(..., max_length=500, description="Article title (URL-encoded)"),
@@ -83,7 +83,7 @@ async def get_article(
     responses={500: {"model": ErrorResponse}},
 )
 @limiter.limit("30/minute")
-async def get_categories(
+def get_categories(
     request: Request,  # noqa: ARG001 - required by slowapi limiter
     response: Response,
     conn: kuzu.Connection = Depends(get_db),
@@ -120,7 +120,7 @@ async def get_categories(
     responses={500: {"model": ErrorResponse}},
 )
 @limiter.limit("30/minute")
-async def get_stats(
+def get_stats(
     request: Request,  # noqa: ARG001 - required by slowapi limiter
     response: Response,
     conn: kuzu.Connection = Depends(get_db),

--- a/backend/api/v1/graph.py
+++ b/backend/api/v1/graph.py
@@ -32,7 +32,7 @@ router = APIRouter(prefix="/api/v1", tags=["graph"])
     },
 )
 @limiter.limit("20/minute")
-async def get_graph(
+def get_graph(
     request: Request,  # noqa: ARG001 - required by slowapi limiter
     response: Response,
     article: str = Query(..., max_length=500, description="Seed article title"),

--- a/backend/api/v1/search.py
+++ b/backend/api/v1/search.py
@@ -32,7 +32,7 @@ router = APIRouter(prefix="/api/v1", tags=["search"])
     },
 )
 @limiter.limit("10/minute")
-async def search(
+def search(
     request: Request,  # noqa: ARG001 - required by slowapi limiter
     response: Response,
     query: str = Query(..., max_length=200, description="Search query (article title)"),
@@ -109,7 +109,7 @@ async def search(
     },
 )
 @limiter.limit("60/minute")
-async def autocomplete(
+def autocomplete(
     request: Request,  # noqa: ARG001 - required by slowapi limiter
     response: Response,
     q: str = Query(

--- a/backend/services/search_service.py
+++ b/backend/services/search_service.py
@@ -100,9 +100,11 @@ class SearchService:
             return []
 
         # Step 2: For each query embedding, find similar sections
+        # Cap at 5 sections to avoid unbounded N queries per article
         all_matches = []
+        max_sections = 5
 
-        for _idx, row in query_df.iterrows():
+        for _idx, row in query_df.head(max_sections).iterrows():
             query_embedding = row["embedding"]
 
             # Query vector index

--- a/bootstrap/src/expansion/processor.py
+++ b/bootstrap/src/expansion/processor.py
@@ -257,6 +257,16 @@ class ArticleProcessor:
                 {"article_title": article.title, "section_id": section_id, "index": i},
             )
 
+        # Clean up existing IN_CATEGORY relationships before re-creating
+        # (prevents duplicate edges on retry/reprocess)
+        self.conn.execute(
+            """
+            MATCH (a:Article {title: $title})-[r:IN_CATEGORY]->()
+            DELETE r
+        """,
+            {"title": article.title},
+        )
+
         # Handle categories
         for cat in article.categories[:3]:  # Limit to 3 main categories
             # Create category if not exists


### PR DESCRIPTION
## Summary

Fixes all 9 issues discovered by the quality audit (#58):

### Critical (Security)
- **#49 Cypher injection**: Add `_validate_cypher()` write-operation filter, parameterize fallback query, validate `max_hops` at runtime

### High (Performance)
- **#50 Async blocking**: Change all endpoint handlers from `async def` to `def` (FastAPI runs sync handlers in threadpool)
- **#51 N+1 link discovery**: Add `_batch_article_exists()` — single query replaces N individual checks
- **#52 N vector queries**: Cap section embeddings to 5 per article in semantic search

### High (Robustness)
- **#53 API error handling**: Catch Claude API errors with graceful fallbacks in both KG Agent and Seed Agent; distinguish auth errors from transient failures

### High (Correctness)
- **#54 Partial insert**: Clean up `IN_CATEGORY` before re-creating on retry; merge `mark_failed` retry+state into single query

### Medium
- **#55 Health check**: Return HTTP 503 when database disconnected
- **#56 Stats**: Add `"processed"` to `get_queue_stats` output
- **#57 Link filter**: Case-insensitive prefix matching; add `Draft:`, `Module:`, `Book:`, `TimedText:` namespaces

### Bonus fixes
- Fix `json.loads` crash on malformed entity properties
- Fix `json.dumps` crash on numpy types in synthesis (`default=str`)
- Add context manager support to `KnowledgeGraphAgent`
- Fix misleading `semantic_search` docstring
- Update Claude model to `claude-haiku-4-5-20251001`

## Files Changed (10)

| File | Changes |
|------|---------|
| `wikigr/agent/kg_agent.py` | Cypher validator, parameterized fallback, API error handling, context manager |
| `wikigr/agent/seed_agent.py` | Auth error detection, empty response handling |
| `backend/api/v1/graph.py` | `async def` → `def` |
| `backend/api/v1/search.py` | `async def` → `def` |
| `backend/api/v1/articles.py` | `async def` → `def` |
| `backend/main.py` | Health check returns 503, `async def` → `def` |
| `backend/services/search_service.py` | Cap section embeddings to 5 |
| `bootstrap/src/expansion/link_discovery.py` | Batch existence check, case-insensitive filter |
| `bootstrap/src/expansion/processor.py` | Clean up IN_CATEGORY on retry |
| `bootstrap/src/expansion/work_queue.py` | Add 'processed' state, merge mark_failed queries |

## Test plan
- [x] 17 seed agent tests passing
- [x] 46 bootstrap tests passing (including previously-failing test_multi_level_expansion)
- [x] ruff lint + format clean
- [x] Pre-commit hooks passing (ruff, format, banned patterns)

Closes #49, #50, #51, #52, #53, #54, #55, #56, #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)