### PR TITLE
Fix all 31 audit round 2 findings

### DIFF
--- a/backend/api/v1/graph.py
+++ b/backend/api/v1/graph.py
@@ -47,7 +47,7 @@ def get_graph(
     Returns nodes and edges within specified depth from seed article.
     """
     # Set cache headers
-    response.headers["Cache-Control"] = "private, max-age=3600"
+    response.headers["Cache-Control"] = "public, max-age=3600"
 
     try:
         result = GraphService.get_graph_neighbors(

--- a/backend/api/v1/search.py
+++ b/backend/api/v1/search.py
@@ -47,7 +47,7 @@ def search(
     Finds articles semantically similar to the query article.
     """
     # Set cache headers
-    response.headers["Cache-Control"] = "private, max-age=3600"
+    response.headers["Cache-Control"] = "public, max-age=3600"
 
     try:
         result = SearchService.semantic_search(
@@ -124,7 +124,7 @@ def autocomplete(
     Returns articles with titles matching the query.
     """
     # Set cache headers
-    response.headers["Cache-Control"] = "private, max-age=3600"
+    response.headers["Cache-Control"] = "public, max-age=3600"
 
     try:
         result = SearchService.autocomplete(

--- a/backend/db/connection.py
+++ b/backend/db/connection.py
@@ -105,4 +105,7 @@ def get_db() -> Generator[kuzu.Connection, None, None]:
         logger.error(f"Database error: {e}")
         raise
     finally:
-        conn.close()
+        try:
+            conn.close()
+        except Exception as close_err:
+            logger.debug(f"Connection close error (non-fatal): {close_err}")

--- a/backend/services/graph_service.py
+++ b/backend/services/graph_service.py
@@ -53,7 +53,7 @@ class GraphService:
         # Validate seed article exists
         result = conn.execute("MATCH (a:Article {title: $title}) RETURN a", {"title": article})
         if not result.has_next():
-            raise ValueError(f"Article not found: {article}")
+            raise ValueError("Article not found")
 
         # Build query for graph traversal.
         # NOTE: depth is interpolated via f-string because Kuzu does not
@@ -149,6 +149,7 @@ class GraphService:
                 MATCH (source:Article)-[link:LINKS_TO]->(target:Article)
                 WHERE source.title IN $titles AND target.title IN $titles
                 RETURN source.title AS source, target.title AS target
+                LIMIT 1000
             """
             edges_result = conn.execute(edges_query, {"titles": node_titles})
             edges_df = edges_result.get_as_df()

--- a/backend/services/search_service.py
+++ b/backend/services/search_service.py
@@ -52,7 +52,7 @@ class SearchService:
         # Validate query article exists
         result = conn.execute("MATCH (a:Article {title: $title}) RETURN a", {"title": query})
         if not result.has_next():
-            raise ValueError(f"Article not found: {query}")
+            raise ValueError("Article not found")
 
         # Use semantic search logic from bootstrap
         results = SearchService._semantic_search_impl(conn, query, category=category, top_k=limit)
@@ -119,7 +119,7 @@ class SearchService:
                 """,
                 {
                     "query_embedding": query_embedding,
-                    "top_k": top_k * 5,  # Over-fetch for aggregation
+                    "top_k": min(top_k * 5, 200),  # Over-fetch for aggregation, capped
                 },
             )
 
@@ -149,7 +149,7 @@ class SearchService:
                     {
                         "article_title": article_title,
                         "distance": distance,
-                        "similarity": 1.0 - distance,
+                        "similarity": max(0.0, min(1.0, 1.0 - distance)),
                     }
                 )
 

--- a/bootstrap/src/expansion/link_discovery.py
+++ b/bootstrap/src/expansion/link_discovery.py
@@ -93,10 +93,15 @@ class LinkDiscovery:
                         )
                 else:
                     # New article - insert as discovered
-                    self._insert_discovered_article(link, next_depth)
+                    try:
+                        self._insert_discovered_article(link, next_depth)
+                        new_articles_count += 1
+                        logger.debug(f"Discovered new article '{link}' at depth {next_depth}")
+                    except Exception as insert_err:
+                        # PK violation if another article already discovered this link
+                        logger.debug(f"Insert race for '{link}': {insert_err}")
+                    # Always create the link edge, even if insert raced
                     self._create_link(source_title, link)
-                    new_articles_count += 1
-                    logger.debug(f"Discovered new article '{link}' at depth {next_depth}")
 
             except Exception as e:
                 logger.warning(f"Failed to process link '{link}': {e}", exc_info=True)

--- a/bootstrap/src/expansion/processor.py
+++ b/bootstrap/src/expansion/processor.py
@@ -84,10 +84,15 @@ class ArticleProcessor:
                 try:
                     article = self.wikipedia_client.fetch_article(redirect_target)
                     logger.info(f"  Fetched redirect target: {len(article.wikitext)} chars")
-                except Exception:
-                    # Skip unfollowable redirects — mark as processed (not failed)
+                except ArticleNotFoundError:
+                    # Redirect target doesn't exist — skip gracefully
                     logger.info(f"  Skipping unfollowable redirect: {title}")
                     return (True, [], None)
+                except Exception as e:
+                    # Transient error — report failure so article gets retried
+                    error_msg = f"Redirect target fetch failed: {e}"
+                    logger.warning(f"  {error_msg}")
+                    return (False, [], error_msg)
 
             sections = parse_sections(article.wikitext)
 

--- a/wikigr/agent/seed_agent.py
+++ b/wikigr/agent/seed_agent.py
@@ -169,14 +169,18 @@ Return ONLY valid JSON:
                 messages=[{"role": "user", "content": prompt}],
             )
         except Exception as e:
-            error_name = type(e).__name__
             # Re-raise auth errors — they won't resolve by retrying
-            if "authentication" in error_name.lower() or "auth" in str(e).lower():
-                raise ValueError(
-                    "Anthropic API authentication failed. "
-                    "Set ANTHROPIC_API_KEY or pass anthropic_api_key=."
-                ) from e
-            logger.error(f"Failed to generate titles for '{topic}': {error_name}: {e}")
+            try:
+                from anthropic import AuthenticationError
+
+                if isinstance(e, AuthenticationError):
+                    raise ValueError(
+                        "Anthropic API authentication failed. "
+                        "Set ANTHROPIC_API_KEY or pass anthropic_api_key=."
+                    ) from e
+            except ImportError:
+                pass
+            logger.error(f"Failed to generate titles for '{topic}': {type(e).__name__}: {e}")
             return []
 
         if not response.content:


### PR DESCRIPTION
## Summary

Fixes all 31 findings from the Round 2 quality audit (#61).

### High Priority (3 fixes)
- **Redirect data loss**: Return failure on transient fetch errors instead of `(True, [], None)` which silently marks empty articles as processed
- **PK violation losing edges**: Always create LINKS_TO edge even when insert races on duplicate primary key
- **CALL bypass in Cypher validator**: Block `CALL` statements (DDL), unbounded variable-length paths `[*]`, strip string literals before keyword scan

### Medium Priority (8 fixes)
- **summary_utils**: Query only lead section (index 0) — was fetching all ~3,400 rows to keep 200
- **graph edge query**: Add `LIMIT 1000` — was unbounded O(N²)
- **vector search over-fetch**: Cap to `min(top_k*5, 200)` — was up to 2,500/section
- **Similarity clamping**: `max(0.0, min(1.0, 1.0 - distance))`
- **State machine guards**: `advance_state` now enforces legal predecessor states
- **CLI safety**: Validate path looks like Kuzu DB before `rmtree`, check file exists before parse
- **Agent robustness**: Complete `json.loads` fix, `_check_open()` guard on all methods, validate `max_results`/`top_k`

### Low Priority (20 fixes)
- Wikipedia URL properly encoded (`urllib.parse.quote`)
- Filesystem traversal capped at 10K files
- Error messages no longer echo user input
- `Cache-Control: public` on public endpoints
- `conn.close()` wrapped in try/except
- SeedAgent auth uses `isinstance` not string matching
- `get_queue_stats` filters NULL states

## Files Changed (13)

| File | Key Changes |
|------|-------------|
| `wikigr/agent/kg_agent.py` | CALL blocking, string literal stripping, unbounded path detection, _safe_json_loads, _check_open, parameter validation |
| `wikigr/agent/seed_agent.py` | isinstance auth detection |
| `wikigr/cli.py` | rmtree safety check, file-not-found guard |
| `backend/services/summary_utils.py` | Lead section only query |
| `backend/services/graph_service.py` | Edge LIMIT 1000, sanitize error |
| `backend/services/search_service.py` | Cap over-fetch, clamp similarity, sanitize error |
| `backend/services/article_service.py` | URL encoding, traversal cap, sanitize error |
| `backend/api/v1/graph.py` | Cache-Control public |
| `backend/api/v1/search.py` | Cache-Control public |
| `backend/db/connection.py` | Safe close |
| `bootstrap/src/expansion/processor.py` | Redirect error handling |
| `bootstrap/src/expansion/link_discovery.py` | PK race fix for edges |
| `bootstrap/src/expansion/work_queue.py` | State guards, NULL filter |

## Test plan
- [x] 63 Python tests passing (17 seed agent + 46 bootstrap)
- [x] ruff lint + format clean
- [x] Pre-commit hooks passing

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)