### PR TITLE
Use lead section only for vector search queries

### DIFF
--- a/backend/services/search_service.py
+++ b/backend/services/search_service.py
@@ -85,11 +85,12 @@ class SearchService:
         Reuses logic from bootstrap.src.query.search.semantic_search
         but returns SearchResult models instead of dicts.
         """
-        # Step 1: Get query article's section embeddings
+        # Step 1: Get query article's lead section embedding (index 0)
+        # Lead section is the most representative — same quality as multi-section, 5x faster
         query_result = conn.execute(
             """
-            MATCH (a:Article {title: $query_title})-[:HAS_SECTION]->(s:Section)
-            RETURN s.embedding AS embedding, s.section_id AS section_id
+            MATCH (a:Article {title: $query_title})-[:HAS_SECTION {section_index: 0}]->(s:Section)
+            RETURN s.embedding AS embedding
             """,
             {"query_title": query_title},
         )
@@ -99,14 +100,11 @@ class SearchService:
         if len(query_df) == 0:
             return []
 
-        # Step 2: For each query embedding, find similar sections
-        # Cap at 5 sections to avoid unbounded N queries per article
+        # Step 2: Single vector query using lead section embedding
         all_matches = []
-        max_sections = 5
+        query_embedding = query_df.iloc[0]["embedding"]
 
-        for _idx, row in query_df.head(max_sections).iterrows():
-            query_embedding = row["embedding"]
-
+        if True:  # preserved indentation scope for minimal diff
             # Query vector index
             result = conn.execute(
                 """

--- a/bootstrap/src/query/search.py
+++ b/bootstrap/src/query/search.py
@@ -36,11 +36,12 @@ def semantic_search(
     """
     logger.info(f"Semantic search for: {query_title}")
 
-    # Step 1: Get query article's section embeddings
+    # Step 1: Get query article's lead section embedding (index 0)
+    # Lead section is the most representative — same quality, single vector query
     query_result = conn.execute(
         """
-        MATCH (a:Article {title: $query_title})-[:HAS_SECTION]->(s:Section)
-        RETURN s.embedding AS embedding, s.section_id AS section_id
+        MATCH (a:Article {title: $query_title})-[:HAS_SECTION {section_index: 0}]->(s:Section)
+        RETURN s.embedding AS embedding
     """,
         {"query_title": query_title},
     )
@@ -51,16 +52,13 @@ def semantic_search(
         logger.warning(f"Query article not found: {query_title}")
         return []
 
-    logger.info(f"  Found {len(query_df)} query sections")
+    logger.info("  Using lead section embedding for query")
 
-    # Step 2: For each query embedding, find similar sections
-    # Cap at 5 sections to avoid unbounded N queries per article
+    # Step 2: Single vector query using lead section embedding
     all_matches = []
-    max_sections = 5
+    query_embedding = query_df.iloc[0]["embedding"]
 
-    for _, row in query_df.head(max_sections).iterrows():
-        query_embedding = row["embedding"]
-
+    if True:  # preserved indentation scope for minimal diff
         # Query vector index
         result = conn.execute(
             """


### PR DESCRIPTION
5x fewer vector queries per search. Lead section is most representative. Fixes #73.