### PR TITLE
Chat endpoint: reuse DB connection via ConnectionManager

### DIFF
--- a/backend/api/v1/chat.py
+++ b/backend/api/v1/chat.py
@@ -2,22 +2,38 @@
 Chat API endpoint.
 
 Wraps KnowledgeGraphAgent for browser-based Q&A against the knowledge graph.
+Uses the shared ConnectionManager (via get_db dependency) instead of opening
+a separate database per request.
 """
 
 import logging
 import os
 import time
 
-from fastapi import APIRouter, Request
+import kuzu
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 
-from backend.config import settings
+from backend.db import get_db
 from backend.models.chat import ChatRequest, ChatResponse
 from backend.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1", tags=["chat"])
+
+# Module-level Anthropic client (created once, reused across requests)
+_anthropic_client = None
+
+
+def _get_anthropic_client():
+    """Get or create a shared Anthropic client."""
+    global _anthropic_client
+    if _anthropic_client is None:
+        from anthropic import Anthropic
+
+        _anthropic_client = Anthropic()
+    return _anthropic_client
 
 
 @router.post(
@@ -31,12 +47,13 @@ router = APIRouter(prefix="/api/v1", tags=["chat"])
 def chat(
     request_body: ChatRequest,
     request: Request,  # noqa: ARG001 - required by slowapi limiter
+    conn: kuzu.Connection = Depends(get_db),
 ) -> ChatResponse | JSONResponse:
     """
     Ask a question about the knowledge graph.
 
-    Creates a fresh KnowledgeGraphAgent per request, queries the graph,
-    and returns a synthesized answer with source citations.
+    Uses the shared database connection pool and a module-level Anthropic client
+    to avoid per-request overhead of opening DB and creating API clients.
 
     Returns HTTP 503 when ANTHROPIC_API_KEY is not configured.
     """
@@ -53,30 +70,17 @@ def chat(
             },
         )
 
-    db_path = settings.database_path
-    if not db_path:
-        logger.error("Chat request rejected: no database path configured")
-        return JSONResponse(
-            status_code=503,
-            content={
-                "error": {
-                    "code": "DATABASE_UNAVAILABLE",
-                    "message": "Knowledge graph database is not configured.",
-                }
-            },
-        )
-
     start = time.perf_counter()
-    agent = None
 
     try:
         from wikigr.agent.kg_agent import KnowledgeGraphAgent
 
-        agent = KnowledgeGraphAgent(
-            db_path=db_path,
-            anthropic_api_key=api_key,
-            read_only=True,
-        )
+        # Create agent with injected connection (no DB open overhead)
+        agent = KnowledgeGraphAgent.__new__(KnowledgeGraphAgent)
+        agent.db = None  # Not managing DB lifecycle
+        agent.conn = conn
+        agent.claude = _get_anthropic_client()
+        agent._embedding_generator = None
 
         result = agent.query(
             question=request_body.question,
@@ -92,18 +96,6 @@ def chat(
             execution_time_ms=round(elapsed_ms, 1),
         )
 
-    except FileNotFoundError:
-        logger.error(f"Database not found at {db_path}")
-        return JSONResponse(
-            status_code=503,
-            content={
-                "error": {
-                    "code": "DATABASE_UNAVAILABLE",
-                    "message": "Knowledge graph database not found at configured path.",
-                }
-            },
-        )
-
     except Exception as e:
         elapsed_ms = (time.perf_counter() - start) * 1000
         logger.error(f"Chat agent error after {elapsed_ms:.0f}ms: {e}", exc_info=True)
@@ -116,10 +108,3 @@ def chat(
                 }
             },
         )
-
-    finally:
-        if agent is not None:
-            try:
-                agent.close()
-            except Exception as close_err:
-                logger.debug(f"Agent close error (non-fatal): {close_err}")


### PR DESCRIPTION
Eliminates per-request DB open and API client creation overhead. Uses Depends(get_db) + module-level Anthropic singleton. Fixes #75.