### PR TITLE
Add backend framework deps to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,17 @@ dev = [
     "pre-commit>=4.0.0,<5.0.0",
 ]
 
+backend = [
+    "fastapi>=0.115.0,<1.0.0",
+    "uvicorn[standard]>=0.34.0,<1.0.0",
+    "python-multipart>=0.0.20,<1.0.0",
+    "slowapi==0.1.9",
+    "sse-starlette>=2.0.0,<3.0.0",
+    "pydantic>=2.10.0,<3.0.0",
+    "pydantic-settings>=2.7.0,<3.0.0",
+    "httpx>=0.28.0,<1.0.0",
+]
+
 test = [
     "pytest>=8.3.0,<9.0.0",
     "pytest-cov>=6.0.0,<7.0.0",


### PR DESCRIPTION
## Summary
- Adds optional `[backend]` dependency group to pyproject.toml
- Declares FastAPI, uvicorn, slowapi, sse-starlette, pydantic, pydantic-settings, python-multipart, httpx
- These were previously only in backend/requirements.txt, not discoverable via pip install

Closes #14

## Test plan
- [x] Pre-commit checks pass (toml validation, formatting)
- [x] Dependency versions match backend/requirements.txt
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)