### PR TITLE
Fix timestamps, API.md, and StatsResponse types

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -158,7 +158,7 @@ async def validation_exception_handler(_request: Request, exc: RequestValidation
                 "code": code,
                 "message": error_msg,
             },
-            "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
+            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         },
     )
 
@@ -177,7 +177,7 @@ async def global_exception_handler(_request, exc):
                 "code": "INTERNAL_ERROR",
                 "message": "An unexpected error occurred",
             },
-            "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
+            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         },
     )
 

--- a/backend/models/article.py
+++ b/backend/models/article.py
@@ -1,6 +1,7 @@
 """Article-related models."""
 
 from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -53,10 +54,10 @@ class CategoryListResponse(BaseModel):
 class StatsResponse(BaseModel):
     """Response for stats endpoint."""
 
-    articles: dict = Field(..., description="Article statistics")
-    sections: dict = Field(..., description="Section statistics")
-    links: dict = Field(..., description="Link statistics")
-    database: dict = Field(..., description="Database information")
-    performance: dict | None = Field(
+    articles: dict[str, Any] = Field(..., description="Article statistics")
+    sections: dict[str, Any] = Field(..., description="Section statistics")
+    links: dict[str, Any] = Field(..., description="Link statistics")
+    database: dict[str, Any] = Field(..., description="Database information")
+    performance: dict[str, Any] | None = Field(
         default=None, description="Performance metrics (populated when available)"
     )

--- a/backend/services/article_service.py
+++ b/backend/services/article_service.py
@@ -284,7 +284,7 @@ class ArticleService:
 
         database = {
             "size_mb": round(db_size_mb, 2),
-            "last_updated": datetime.now(timezone.utc).isoformat() + "Z",
+            "last_updated": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         }
 
         result = StatsResponse(


### PR DESCRIPTION
## Summary
- Fix 3 malformed timestamps producing double timezone suffix (`+00:00Z`)
- Type `StatsResponse` dict fields as `dict[str, Any]` for proper OpenAPI schema
- Update API.md: add hybrid-search + chat endpoints, remove unimplemented features, add rate limiting docs

Closes #18

## Test plan
- [x] 30/30 articles+graph backend tests pass
- [x] Pre-commit checks pass (ruff lint + format)
- [x] API.md now reflects actual implemented endpoints
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)