### PR TITLE
Wire up autocomplete suggestions in SearchBar

### DIFF
--- a/frontend/e2e/search.spec.ts
+++ b/frontend/e2e/search.spec.ts
@@ -1,6 +1,29 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Search workflows', () => {
+  test('autocomplete shows suggestions when typing', async ({ page }) => {
+    await page.goto('/');
+    const searchInput = page.getByRole('combobox');
+    await searchInput.fill('art');
+    // Wait for debounce + API response
+    await expect(page.getByRole('listbox')).toBeVisible({ timeout: 5000 });
+    // Should show "Artificial intelligence" as a suggestion
+    await expect(page.getByRole('option').first()).toBeVisible();
+  });
+
+  test('clicking autocomplete suggestion loads graph', async ({ page }) => {
+    await page.goto('/');
+    const searchInput = page.getByRole('combobox');
+    await searchInput.fill('art');
+    await expect(page.getByRole('listbox')).toBeVisible({ timeout: 5000 });
+
+    // Click the first suggestion
+    await page.getByRole('option').first().click();
+
+    // Graph should load - look for SVG with nodes
+    await expect(page.locator('svg circle').first()).toBeVisible({ timeout: 15000 });
+  });
+
   test('submitting search via Enter loads graph', async ({ page }) => {
     await page.goto('/');
     const searchInput = page.getByRole('combobox');

--- a/frontend/src/components/Search/SearchBar.tsx
+++ b/frontend/src/components/Search/SearchBar.tsx
@@ -8,6 +8,7 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 
 interface SearchBarProps {
   onSearch: (query: string) => void;
+  onAutocomplete?: (query: string) => void;
   onModeChange?: (mode: 'text' | 'semantic') => void;
   mode?: 'text' | 'semantic';
   suggestions?: Array<{ title: string; category: string }>;
@@ -19,6 +20,7 @@ interface SearchBarProps {
 
 export const SearchBar: React.FC<SearchBarProps> = ({
   onSearch,
+  onAutocomplete,
   onModeChange,
   mode = 'text',
   suggestions = [],
@@ -40,27 +42,27 @@ export const SearchBar: React.FC<SearchBarProps> = ({
     }
   }, [autoFocus]);
 
-  // Debounced search
+  // Debounced autocomplete while typing
   const handleInputChange = useCallback(
     (value: string) => {
       setQuery(value);
 
-      // Cancel pending search
+      // Cancel pending autocomplete
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
 
-      // Schedule new search
-      if (value.length >= 2) {
+      // Schedule autocomplete fetch (lightweight, not full search)
+      if (value.length >= 2 && onAutocomplete) {
         timeoutRef.current = setTimeout(() => {
-          onSearch(value);
+          onAutocomplete(value);
         }, debounceMs);
       }
 
       // Show suggestions when typing
       setShowSuggestions(value.length >= 2 && suggestions.length > 0);
     },
-    [onSearch, debounceMs, suggestions.length]
+    [onAutocomplete, debounceMs, suggestions.length]
   );
 
   // Clear input


### PR DESCRIPTION
## Summary
Fix bug where SearchBar's autocomplete dropdown never appeared.

**Root cause**: App.tsx never called the autocomplete API while the user types. The `suggestions` prop was always empty.

**Also fixes**: Semantic search was firing on every debounced keystroke (expensive). Now only fires on Enter/submit.

### Changes
- Add `onAutocomplete` prop to SearchBar (lightweight, debounced typing)
- `onSearch` now only fires on Enter/submit/suggestion click (heavy)
- App.tsx calls `autocomplete()` API during typing, passes results to SearchBar
- Added 2 new E2E tests verifying autocomplete works

Closes #111

## Test plan
- [x] 23/23 E2E tests pass (including 2 new autocomplete tests)
- [x] Autocomplete dropdown appears when typing "art" → shows "Artificial intelligence"
- [x] Clicking suggestion loads graph
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)