### PR TITLE
Add pluggable ContentSource for web content

### DIFF
--- a/bootstrap/src/sources/__init__.py
+++ b/bootstrap/src/sources/__init__.py
@@ -1,0 +1,17 @@
+"""Pluggable content sources for WikiGR knowledge graph construction.
+
+Provides an abstract ContentSource protocol and implementations for
+Wikipedia and generic web content.
+"""
+
+from .base import Article, ArticleNotFoundError, ContentSource
+from .web import WebContentSource
+from .wikipedia_source import WikipediaContentSource
+
+__all__ = [
+    "Article",
+    "ArticleNotFoundError",
+    "ContentSource",
+    "WebContentSource",
+    "WikipediaContentSource",
+]

--- a/bootstrap/src/sources/base.py
+++ b/bootstrap/src/sources/base.py
@@ -1,0 +1,75 @@
+"""Abstract content source protocol for WikiGR.
+
+Defines the interface that all content sources (Wikipedia, web, etc.) must implement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+
+@dataclass
+class Article:
+    """Source-agnostic article representation.
+
+    This is the common data structure returned by all ContentSource
+    implementations. It replaces the Wikipedia-specific WikipediaArticle
+    for new code paths while remaining compatible with existing pipeline code.
+    """
+
+    title: str
+    content: str  # Raw text content (wikitext for Wikipedia, markdown for web)
+    links: list[str] = field(default_factory=list)
+    categories: list[str] = field(default_factory=list)
+    source_url: str = ""
+    source_type: str = "unknown"  # "wikipedia", "web", etc.
+
+
+class ArticleNotFoundError(Exception):
+    """Raised when a content source cannot find the requested article."""
+
+
+@runtime_checkable
+class ContentSource(Protocol):
+    """Protocol for pluggable content sources.
+
+    Implementations must provide methods to fetch articles, parse them
+    into sections, and extract outgoing links.
+    """
+
+    def fetch_article(self, title_or_url: str) -> Article:
+        """Fetch an article by title (Wikipedia) or URL (web).
+
+        Args:
+            title_or_url: Article title for named sources, or full URL for web.
+
+        Returns:
+            Article with content, links, and categories populated.
+
+        Raises:
+            ArticleNotFoundError: If the article/URL cannot be fetched.
+        """
+        ...
+
+    def parse_sections(self, content: str) -> list[dict]:
+        """Parse article content into sections.
+
+        Args:
+            content: Raw article content (wikitext, markdown, HTML).
+
+        Returns:
+            List of dicts with keys: title, content, level.
+        """
+        ...
+
+    def get_links(self, content: str) -> list[str]:
+        """Extract outgoing links from article content.
+
+        Args:
+            content: Raw article content.
+
+        Returns:
+            List of link targets (titles for Wikipedia, URLs for web).
+        """
+        ...

--- a/bootstrap/src/sources/web.py
+++ b/bootstrap/src/sources/web.py
@@ -1,0 +1,232 @@
+"""Generic web content source implementation.
+
+Fetches and parses arbitrary web pages into the Article format,
+enabling knowledge graph construction from any documentation site
+(e.g., Microsoft Learn, MDN, ReadTheDocs).
+"""
+
+import logging
+import re
+from urllib.parse import urljoin, urlparse
+
+import requests
+
+from .base import Article, ArticleNotFoundError, ContentSource
+
+logger = logging.getLogger(__name__)
+
+
+def _html_to_markdown(html: str) -> str:
+    """Convert HTML to markdown-like plain text.
+
+    Simple converter that handles common HTML elements without
+    requiring heavy dependencies like html2text or markdownify.
+    """
+    import html as html_mod
+
+    text = html
+
+    # Remove script and style blocks
+    text = re.sub(r"<script[^>]*>.*?</script>", "", text, flags=re.DOTALL)
+    text = re.sub(r"<style[^>]*>.*?</style>", "", text, flags=re.DOTALL)
+    text = re.sub(r"<nav[^>]*>.*?</nav>", "", text, flags=re.DOTALL)
+    text = re.sub(r"<footer[^>]*>.*?</footer>", "", text, flags=re.DOTALL)
+    text = re.sub(r"<header[^>]*>.*?</header>", "", text, flags=re.DOTALL)
+
+    # Convert headings to markdown
+    for level in range(1, 7):
+        text = re.sub(
+            rf"<h{level}[^>]*>(.*?)</h{level}>",
+            lambda m, lv=level: f"\n{'#' * lv} {m.group(1).strip()}\n",
+            text,
+            flags=re.DOTALL,
+        )
+
+    # Convert paragraphs to double newlines
+    text = re.sub(r"<p[^>]*>(.*?)</p>", r"\1\n\n", text, flags=re.DOTALL)
+
+    # Convert list items
+    text = re.sub(r"<li[^>]*>(.*?)</li>", r"- \1\n", text, flags=re.DOTALL)
+
+    # Convert links: <a href="url">text</a> -> text
+    text = re.sub(r"<a[^>]*>(.*?)</a>", r"\1", text, flags=re.DOTALL)
+
+    # Convert code blocks
+    text = re.sub(r"<pre[^>]*>(.*?)</pre>", r"```\n\1\n```\n", text, flags=re.DOTALL)
+    text = re.sub(r"<code[^>]*>(.*?)</code>", r"`\1`", text, flags=re.DOTALL)
+
+    # Strip remaining HTML tags
+    text = re.sub(r"<[^>]+>", "", text)
+
+    # Decode HTML entities
+    text = html_mod.unescape(text)
+
+    # Clean up whitespace
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    text = re.sub(r"[ \t]+", " ", text)
+
+    return text.strip()
+
+
+def _extract_links(html: str, base_url: str) -> list[str]:
+    """Extract absolute URLs from HTML anchor tags."""
+    links = []
+    for match in re.finditer(r'<a[^>]+href="([^"]*)"', html):
+        href = match.group(1)
+        if href.startswith("#") or href.startswith("javascript:"):
+            continue
+        absolute = urljoin(base_url, href)
+        # Only include links from the same domain
+        if urlparse(absolute).netloc == urlparse(base_url).netloc:
+            links.append(absolute)
+    return list(dict.fromkeys(links))  # Dedupe preserving order
+
+
+def _extract_title(html: str, url: str) -> str:
+    """Extract page title from HTML or fall back to URL path."""
+    match = re.search(r"<title[^>]*>(.*?)</title>", html, re.DOTALL)
+    if match:
+        title = match.group(1).strip()
+        # Clean common suffixes like " | Microsoft Learn"
+        title = re.split(r"\s*[|–—]\s*", title)[0].strip()
+        if title:
+            return title
+    # Fall back to URL path
+    path = urlparse(url).path.rstrip("/").split("/")[-1]
+    return path.replace("-", " ").replace("_", " ").title()
+
+
+def _infer_categories(url: str) -> list[str]:
+    """Infer categories from URL path segments and content."""
+    categories = []
+    path = urlparse(url).path.strip("/")
+    segments = [s for s in path.split("/") if s and len(s) > 2]
+    # Use path segments as categories (e.g., /azure/kubernetes/ -> ["azure", "kubernetes"])
+    for seg in segments[:3]:
+        clean = seg.replace("-", " ").replace("_", " ").title()
+        if clean.lower() not in ("en", "us", "docs", "index", "learn"):
+            categories.append(clean)
+    return categories
+
+
+class WebContentSource:
+    """ContentSource implementation for generic web pages.
+
+    Fetches HTML from any URL, converts to markdown-like text, and
+    extracts sections, links, and categories. Works with documentation
+    sites like Microsoft Learn, MDN, ReadTheDocs, etc.
+    """
+
+    def __init__(
+        self,
+        user_agent: str = "WikiGR/1.0 (Knowledge Graph Builder)",
+        timeout: int = 30,
+        rate_limit_delay: float = 0.5,
+    ):
+        self._session = requests.Session()
+        self._session.headers["User-Agent"] = user_agent
+        self._timeout = timeout
+        self._rate_limit_delay = rate_limit_delay
+        self._last_request_time = 0.0
+
+    def fetch_article(self, title_or_url: str) -> Article:
+        """Fetch a web page by URL.
+
+        Args:
+            title_or_url: Full URL to fetch.
+
+        Returns:
+            Article with markdown content, links, and inferred categories.
+
+        Raises:
+            ArticleNotFoundError: If the URL returns 404 or fails.
+        """
+        import time
+
+        # Rate limiting
+        elapsed = time.time() - self._last_request_time
+        if elapsed < self._rate_limit_delay:
+            time.sleep(self._rate_limit_delay - elapsed)
+
+        try:
+            response = self._session.get(title_or_url, timeout=self._timeout)
+            self._last_request_time = time.time()
+
+            if response.status_code == 404:
+                raise ArticleNotFoundError(f"Page not found: {title_or_url}")
+            response.raise_for_status()
+        except requests.RequestException as e:
+            raise ArticleNotFoundError(f"Failed to fetch {title_or_url}: {e}") from e
+
+        html = response.text
+        title = _extract_title(html, title_or_url)
+        markdown = _html_to_markdown(html)
+        links = _extract_links(html, title_or_url)
+        categories = _infer_categories(title_or_url)
+
+        logger.info(f"Fetched web page: {title} ({len(markdown)} chars, {len(links)} links)")
+
+        return Article(
+            title=title,
+            content=markdown,
+            links=links,
+            categories=categories,
+            source_url=title_or_url,
+            source_type="web",
+        )
+
+    def parse_sections(self, content: str) -> list[dict]:
+        """Parse markdown-like content into sections by headings."""
+        sections: list[dict] = []
+        current_title = ""
+        current_level = 0
+        current_lines: list[str] = []
+
+        for line in content.split("\n"):
+            heading_match = re.match(r"^(#{1,6})\s+(.+)$", line)
+            if heading_match:
+                # Save previous section
+                if current_lines:
+                    text = "\n".join(current_lines).strip()
+                    if text and len(text) > 20:
+                        sections.append(
+                            {
+                                "title": current_title or "Introduction",
+                                "content": text,
+                                "level": current_level or 2,
+                            }
+                        )
+                current_level = len(heading_match.group(1))
+                current_title = heading_match.group(2).strip()
+                current_lines = []
+            else:
+                current_lines.append(line)
+
+        # Save last section
+        if current_lines:
+            text = "\n".join(current_lines).strip()
+            if text and len(text) > 20:
+                sections.append(
+                    {
+                        "title": current_title or "Introduction",
+                        "content": text,
+                        "level": current_level or 2,
+                    }
+                )
+
+        return sections
+
+    def get_links(self, content: str) -> list[str]:
+        """Extract URLs from markdown-like content.
+
+        Note: Links are already extracted during fetch_article(). This
+        method re-extracts from the converted markdown text.
+        """
+        links = []
+        for match in re.finditer(r"https?://[^\s<>\"')\]]+", content):
+            links.append(match.group(0))
+        return list(dict.fromkeys(links))
+
+
+# Verify protocol compliance
+assert isinstance(WebContentSource(), ContentSource)

--- a/bootstrap/src/sources/wikipedia_source.py
+++ b/bootstrap/src/sources/wikipedia_source.py
@@ -1,0 +1,73 @@
+"""Wikipedia content source implementation.
+
+Wraps the existing WikipediaAPIClient to implement the ContentSource protocol.
+"""
+
+import logging
+
+from ..wikipedia import ArticleNotFoundError as WikiNotFoundError
+from ..wikipedia import WikipediaAPIClient, WikipediaArticle
+from ..wikipedia.parser import parse_sections
+from .base import Article, ArticleNotFoundError, ContentSource
+
+logger = logging.getLogger(__name__)
+
+
+class WikipediaContentSource:
+    """ContentSource implementation for Wikipedia articles.
+
+    Wraps the existing WikipediaAPIClient, adapting WikipediaArticle
+    to the common Article dataclass.
+    """
+
+    def __init__(self, client: WikipediaAPIClient | None = None):
+        self._client = client or WikipediaAPIClient()
+
+    def fetch_article(self, title_or_url: str) -> Article:
+        """Fetch a Wikipedia article by title.
+
+        Args:
+            title_or_url: Wikipedia article title.
+
+        Returns:
+            Article with wikitext content, links, and categories.
+
+        Raises:
+            ArticleNotFoundError: If the article doesn't exist.
+        """
+        try:
+            wiki_article: WikipediaArticle = self._client.fetch_article(title_or_url)
+        except WikiNotFoundError as e:
+            raise ArticleNotFoundError(str(e)) from e
+
+        return Article(
+            title=wiki_article.title,
+            content=wiki_article.wikitext,
+            links=wiki_article.links,
+            categories=wiki_article.categories,
+            source_url=f"https://en.wikipedia.org/wiki/{wiki_article.title.replace(' ', '_')}",
+            source_type="wikipedia",
+        )
+
+    def parse_sections(self, content: str) -> list[dict]:
+        """Parse wikitext into sections using the existing parser."""
+        return parse_sections(content)
+
+    def get_links(self, content: str) -> list[str]:
+        """Extract wiki links from wikitext.
+
+        Note: Links are already extracted during fetch_article() and stored
+        in Article.links. This method provides an alternative for re-parsing.
+        """
+        import re
+
+        links = []
+        for match in re.finditer(r"\[\[([^|\]]+)(?:\|[^\]]+)?\]\]", content):
+            link = match.group(1).strip()
+            if not link.startswith(("File:", "Image:", "Category:", "Wikipedia:", "Help:")):
+                links.append(link)
+        return links
+
+
+# Verify protocol compliance
+assert isinstance(WikipediaContentSource(), ContentSource)


### PR DESCRIPTION
## Summary
Create abstract ContentSource protocol with Wikipedia and generic web implementations. Enables building KGs from any documentation site.

Tested against Microsoft Learn: extracts title, content, 41 links, 10 sections.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)