### PR TITLE
Fix remaining audit findings across all workstreams

### DIFF
--- a/bootstrap/src/sources/wikipedia_source.py
+++ b/bootstrap/src/sources/wikipedia_source.py
@@ -4,6 +4,7 @@ Wraps the existing WikipediaAPIClient to implement the ContentSource protocol.
 """
 
 import logging
+import re
 
 from ..wikipedia import ArticleNotFoundError as WikiNotFoundError
 from ..wikipedia import WikipediaAPIClient, WikipediaArticle
@@ -59,8 +60,6 @@ class WikipediaContentSource:
         Note: Links are already extracted during fetch_article() and stored
         in Article.links. This method provides an alternative for re-parsing.
         """
-        import re
-
         links = []
         for match in re.finditer(r"\[\[([^|\]]+)(?:\|[^\]]+)?\]\]", content):
             link = match.group(1).strip()

--- a/frontend/e2e/filters.spec.ts
+++ b/frontend/e2e/filters.spec.ts
@@ -1,12 +1,5 @@
 import { test, expect } from '@playwright/test';
-
-async function loadGraph(page: import('@playwright/test').Page) {
-  await page.goto('/');
-  const searchInput = page.getByRole('combobox');
-  await searchInput.fill('Artificial intelligence');
-  await searchInput.press('Enter');
-  await expect(page.locator('svg circle').first()).toBeVisible({ timeout: 15000 });
-}
+import { loadGraph } from './helpers';
 
 test.describe('Filter panel', () => {
   test('filter panel is visible after graph loads', async ({ page }) => {

--- a/frontend/e2e/graph-keyboard.spec.ts
+++ b/frontend/e2e/graph-keyboard.spec.ts
@@ -1,14 +1,5 @@
 import { test, expect } from '@playwright/test';
-
-async function loadGraph(page: import('@playwright/test').Page) {
-  await page.goto('/');
-  const searchInput = page.getByRole('combobox');
-  await searchInput.fill('Artificial intelligence');
-  await searchInput.press('Enter');
-  await expect(page.locator('svg circle').first()).toBeVisible({ timeout: 15000 });
-  // Wait for simulation to settle
-  await page.waitForTimeout(2000);
-}
+import { loadGraph } from './helpers';
 
 test.describe('Graph keyboard zoom/pan', () => {
   test('SVG has aria-label with keyboard instructions', async ({ page }) => {

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -1,0 +1,14 @@
+import { expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+/**
+ * Load a graph by searching for an article and waiting for nodes to render.
+ * Shared across E2E test suites.
+ */
+export async function loadGraph(page: Page, article = 'Artificial intelligence') {
+  await page.goto('/');
+  const searchInput = page.getByRole('combobox');
+  await searchInput.fill(article);
+  await searchInput.press('Enter');
+  await expect(page.locator('svg circle').first()).toBeVisible({ timeout: 15000 });
+}

--- a/frontend/e2e/pwa.spec.ts
+++ b/frontend/e2e/pwa.spec.ts
@@ -19,14 +19,12 @@ test.describe('PWA basics', () => {
     await expect(html).toHaveAttribute('lang', /en/);
   });
 
-  test('manifest link is present', async ({ page }) => {
+  test('manifest link is present with valid href', async ({ page }) => {
     await page.goto('/');
-    // PWA manifest should be linked in the HTML
     const manifest = page.locator('link[rel="manifest"]');
-    if ((await manifest.count()) > 0) {
-      const href = await manifest.getAttribute('href');
-      expect(href).toBeTruthy();
-    }
+    await expect(manifest).toHaveCount(1);
+    const href = await manifest.getAttribute('href');
+    expect(href).toBeTruthy();
   });
 
   test('app loads without JavaScript errors', async ({ page }) => {
@@ -35,7 +33,7 @@ test.describe('PWA basics', () => {
       jsErrors.push(error.message);
     });
     await page.goto('/');
-    await page.waitForTimeout(3000);
+    await page.waitForLoadState('networkidle');
     expect(jsErrors).toHaveLength(0);
   });
 });

--- a/frontend/e2e/search.spec.ts
+++ b/frontend/e2e/search.spec.ts
@@ -100,9 +100,10 @@ test.describe('Search workflows', () => {
     const searchInput = page.getByRole('combobox');
     await searchInput.fill('xyznonexistent12345');
     await searchInput.press('Enter');
-    await page.waitForTimeout(3000);
-    // Page should not crash
-    await expect(searchInput).toBeVisible();
+    // Should show error or empty state — no graph nodes rendered
+    await expect(searchInput).toBeVisible({ timeout: 5000 });
+    const nodeCount = await page.locator('svg circle').count();
+    expect(nodeCount).toBe(0);
   });
 
   test('search results show nodes in graph', async ({ page }) => {

--- a/frontend/src/components/Search/SearchBar.tsx
+++ b/frontend/src/components/Search/SearchBar.tsx
@@ -58,11 +58,8 @@ export const SearchBar: React.FC<SearchBarProps> = ({
           onAutocomplete(value);
         }, debounceMs);
       }
-
-      // Show suggestions when typing
-      setShowSuggestions(value.length >= 2 && suggestions.length > 0);
     },
-    [onAutocomplete, debounceMs, suggestions.length]
+    [onAutocomplete, debounceMs]
   );
 
   // Clear input
@@ -130,10 +127,20 @@ export const SearchBar: React.FC<SearchBarProps> = ({
     }
   }, [mode, onModeChange]);
 
-  // Show suggestions when suggestions prop changes
+  // Show suggestions when suggestions prop changes; reset keyboard selection
   useEffect(() => {
     setShowSuggestions(suggestions.length > 0);
+    setSelectedIndex(-1);
   }, [suggestions]);
+
+  // Cleanup debounce timer on unmount
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   return (
     <div className="relative w-full">


### PR DESCRIPTION
## Summary

Fixes 23 remaining audit findings across 5 workstreams (A-E), organized by component.

### Workstream A — KG Agent (5 fixes)
- Gate hybrid retrieval on query type — skip for entity_search/entity_relationships (saves 12+ queries)
- Batch `_fetch_source_text` into single `WHERE IN` query (was 5 sequential N+1)
- Validate `_plan_query_uncached` JSON has required keys before returning
- Replace plan cache cap-and-stop with proper LRU eviction
- Upgrade hybrid semantic_search failure from debug to warning

### Workstream B — SearchBar (3 fixes)
- Remove stale `showSuggestions` from `handleInputChange` closure (fixes flicker)
- Reset `selectedIndex` when suggestions change (prevents out-of-bounds crash)
- Add cleanup `useEffect` to clear debounce timer on unmount (memory leak)

### Workstream C — E2E Tests (5 fixes)
- Fix vacuous `count >= 0` assertion that never fails
- Remove vacuous conditional guards (Wikipedia link, manifest)
- Replace hardcoded `waitForTimeout` with condition-based waits
- Assert no graph nodes on nonexistent search
- Extract shared `loadGraph` helper to `e2e/helpers.ts`

### Workstream D — Web Source (4 fixes)
- Replace regex HTML parsing with stdlib `html.parser` (HTMLParser)
- Add encoding detection for non-UTF-8 pages
- HTML-unescape page titles
- Move lazy `import re` to module level, remove module-level asserts

### Workstream E — Chunker (2 fixes)
- Sentence boundary now detects `?` and `!` (not just `.`)
- Use `|` separator in chunk_id (safe for titles with `#`)

Addresses #133

## Test plan
- [x] 44/44 expansion + integration tests pass
- [x] Ruff lint + format pass
- [x] Pre-commit passes
- [ ] E2E tests (require servers — some tests changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)