### PR TITLE
Add URL validator with rate-limit handling

### DIFF
--- a/data/packs/rust-expert/urls.txt
+++ b/data/packs/rust-expert/urls.txt
@@ -124,10 +124,10 @@ https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html
 # Advanced Features (Critical - 10% unsafe)
 https://doc.rust-lang.org/book/ch19-00-advanced-features.html
 https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html
-https://doc.rust-lang.org/book/ch19-02-advanced-traits.html
-https://doc.rust-lang.org/book/ch19-03-advanced-types.html
-https://doc.rust-lang.org/book/ch19-04-advanced-functions-and-closures.html
-https://doc.rust-lang.org/book/ch19-05-macros.html
+# REMOVED (404): https://doc.rust-lang.org/book/ch19-02-advanced-traits.html
+# REMOVED (404): https://doc.rust-lang.org/book/ch19-03-advanced-types.html
+# REMOVED (404): https://doc.rust-lang.org/book/ch19-04-advanced-functions-and-closures.html
+# REMOVED (404): https://doc.rust-lang.org/book/ch19-05-macros.html
 
 # Final Project - Web Server
 https://doc.rust-lang.org/book/ch20-00-final-project-a-web-server.html
@@ -262,9 +262,9 @@ https://doc.rust-lang.org/rust-by-example/scope/lifetime/fn.html
 https://doc.rust-lang.org/rust-by-example/scope/lifetime/methods.html
 https://doc.rust-lang.org/rust-by-example/scope/lifetime/struct.html
 https://doc.rust-lang.org/rust-by-example/scope/lifetime/trait.html
-https://doc.rust-lang.org/rust-by-example/scope/lifetime/bounds.html
-https://doc.rust-lang.org/rust-by-example/scope/lifetime/coercion.html
-https://doc.rust-lang.org/rust-by-example/scope/lifetime/static.html
+# REMOVED (404): https://doc.rust-lang.org/rust-by-example/scope/lifetime/bounds.html
+# REMOVED (404): https://doc.rust-lang.org/rust-by-example/scope/lifetime/coercion.html
+# REMOVED (404): https://doc.rust-lang.org/rust-by-example/scope/lifetime/static.html
 https://doc.rust-lang.org/rust-by-example/scope/lifetime/elision.html
 
 # Traits (20% traits coverage)
@@ -347,10 +347,10 @@ https://doc.rust-lang.org/reference/types/inferred.html
 
 # Type Layout
 https://doc.rust-lang.org/reference/type-layout.html
-https://doc.rust-lang.org/reference/type-layout/size-and-alignment.html
-https://doc.rust-lang.org/reference/type-layout/repr-rust.html
-https://doc.rust-lang.org/reference/type-layout/repr-transparent.html
-https://doc.rust-lang.org/reference/type-layout/repr-c.html
+# REMOVED (404): https://doc.rust-lang.org/reference/type-layout/size-and-alignment.html
+# REMOVED (404): https://doc.rust-lang.org/reference/type-layout/repr-rust.html
+# REMOVED (404): https://doc.rust-lang.org/reference/type-layout/repr-transparent.html
+# REMOVED (404): https://doc.rust-lang.org/reference/type-layout/repr-c.html
 
 # Items and Attributes
 https://doc.rust-lang.org/reference/items.html

--- a/scripts/validate_pack_urls.py
+++ b/scripts/validate_pack_urls.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Validate URLs in pack urls.txt files. Removes hallucinated/dead URLs.
+
+Usage:
+    python scripts/validate_pack_urls.py data/packs/dotnet-expert/urls.txt
+    python scripts/validate_pack_urls.py --all  # Validate all packs
+"""
+
+import argparse
+import concurrent.futures
+import sys
+from pathlib import Path
+
+import requests
+
+
+def check_url(url: str, timeout: int = 10, retries: int = 2) -> tuple[str, int, str]:
+    """Check if URL is reachable. Returns (url, status_code, reason).
+
+    Retries on 429 (rate limit) with exponential backoff.
+    Treats 429 as VALID (the URL exists, just rate-limited).
+    """
+    import time as _time
+    for attempt in range(retries + 1):
+        try:
+            r = requests.head(url, timeout=timeout, allow_redirects=True)
+            if r.status_code == 429:
+                # Rate limited - URL is valid, just throttled
+                if attempt < retries:
+                    _time.sleep(2 ** attempt)
+                    continue
+                return (url, 200, "ok (rate-limited but valid)")
+            return (url, r.status_code, "ok" if r.status_code < 400 else f"HTTP {r.status_code}")
+        except requests.ConnectionError:
+            return (url, 0, "connection_error")
+        except requests.Timeout:
+            if attempt < retries:
+                _time.sleep(1)
+                continue
+            return (url, 0, "timeout")
+        except Exception as e:
+            return (url, 0, str(e)[:60])
+    return (url, 0, "max_retries")
+
+
+def load_urls(path: Path) -> list[str]:
+    with open(path) as f:
+        return [
+            line.strip() for line in f
+            if line.strip() and not line.strip().startswith("#") and line.strip().startswith("http")
+        ]
+
+
+def validate_file(urls_path: Path, fix: bool = False, workers: int = 10) -> dict:
+    urls = load_urls(urls_path)
+    print(f"Validating {len(urls)} URLs from {urls_path}...")
+
+    results = {"valid": [], "invalid": []}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(check_url, url): url for url in urls}
+        for i, future in enumerate(concurrent.futures.as_completed(futures), 1):
+            url, status, reason = future.result()
+            if status < 400 and status > 0:
+                results["valid"].append(url)
+            else:
+                results["invalid"].append((url, status, reason))
+                print(f"  ❌ [{status}] {url} ({reason})")
+            if i % 50 == 0:
+                print(f"  ... checked {i}/{len(urls)}")
+
+    print(f"\nResults: {len(results['valid'])} valid, {len(results['invalid'])} invalid")
+
+    if fix and results["invalid"]:
+        # Rewrite urls.txt with only valid URLs, preserving comments
+        with open(urls_path) as f:
+            lines = f.readlines()
+        invalid_urls = {u for u, _, _ in results["invalid"]}
+        with open(urls_path, "w") as f:
+            removed = 0
+            for line in lines:
+                stripped = line.strip()
+                if stripped in invalid_urls:
+                    f.write(f"# REMOVED (404): {stripped}\n")
+                    removed += 1
+                else:
+                    f.write(line)
+        print(f"Fixed: commented out {removed} invalid URLs in {urls_path}")
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate pack URLs")
+    parser.add_argument("urls_file", nargs="?", help="Path to urls.txt")
+    parser.add_argument("--all", action="store_true", help="Validate all packs")
+    parser.add_argument("--fix", action="store_true", help="Remove invalid URLs from file")
+    parser.add_argument("--workers", type=int, default=10, help="Concurrent workers")
+    args = parser.parse_args()
+
+    if args.all:
+        for urls_file in sorted(Path("data/packs").glob("*/urls.txt")):
+            print(f"\n{'=' * 60}")
+            validate_file(urls_file, fix=args.fix, workers=args.workers)
+    elif args.urls_file:
+        validate_file(Path(args.urls_file), fix=args.fix, workers=args.workers)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Prevents hallucinated URLs from wasting build time. Handles 429 rate limiting. Fixes 11 Rust hallucinated URLs.