### PR TITLE
Fix fundamental KG Agent flaws: model→opus, augment prompt, rich context

### DIFF
--- a/scripts/run_all_packs_evaluation.py
+++ b/scripts/run_all_packs_evaluation.py
@@ -21,7 +21,7 @@ from anthropic import Anthropic
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
-MODEL = "claude-sonnet-4-5-20250929"
+MODEL = "claude-opus-4-6"
 JUDGE_MODEL = "claude-haiku-4-5-20251001"
 
 

--- a/scripts/run_enhancement_evaluation.py
+++ b/scripts/run_enhancement_evaluation.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 PACK_DIR = Path("data/packs/physics-expert")
 QUESTIONS_FILE = PACK_DIR / "eval" / "questions.jsonl"
 SAMPLE_SIZE = 10  # Evaluate 10 questions per baseline
-MODEL = "claude-sonnet-4-5-20250929"
+MODEL = "claude-opus-4-6"
 
 
 def load_sample_questions(path: Path, n: int) -> list[dict]:


### PR DESCRIPTION
## Summary

Three critical fixes that address why knowledge packs scored 3.3/10 (22%) vs training 8.3/10 (91%):

1. **Model**: All synthesis → `claude-opus-4-6` (was `claude-haiku-4-5`). Eval training baseline also → opus. Added `synthesis_model` constructor param.
2. **Prompt**: "Answer ONLY from KG" → "Use BOTH your expertise AND retrieved content." KG augments instead of replacing.
3. **Retrieval**: `semantic_search()` now captures section content from vector results (was discarding it). `_fetch_source_text()` works for all pack types (removed broken `section_index` dependency). 3000 char/article (was 500).

## Before/After

**Before** (Haiku + empty context):
```
Q: What is the formula for kinetic energy?
A: E ∝ mv² (WRONG - Leibniz vis viva, not modern formula)
   context: EMPTY, sources: 10 titles only, facts: 0
```

**After** (Opus + rich context):
```
Q: What is the formula for kinetic energy?
A: KE = ½mv² (CORRECT - full explanation with derivation)
   context: 22 facts with actual section content, sources: 10 with text
```

## Test plan

- [x] 43 tests passing (test_reranker.py + test_kg_agent_semantic.py)
- [x] Manual test: physics pack kinetic energy question → correct answer with rich context
- [x] Pre-commit passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)