### PR TITLE
Remove _score_content stub, fix tar symlink bypass

### DIFF
--- a/wikigr/packs/distribution.py
+++ b/wikigr/packs/distribution.py
@@ -129,10 +129,14 @@ def unpackage_pack(archive_path: Path, install_dir: Path) -> Path:
 
         # Extract archive
         with tarfile.open(archive_path, "r:gz") as tar:
-            # Security check: ensure no absolute paths or parent refs
+            # Security check: ensure no absolute paths, parent refs, or symlinks
             for member in tar.getmembers():
                 if member.name.startswith("/") or ".." in member.name:
                     raise ValueError(f"Invalid archive member path: {member.name}")
+                if member.issym() or member.islnk():
+                    raise ValueError(
+                        f"Symlinks/hardlinks not allowed in pack archives: {member.name}"
+                    )
 
             # Extract all files
             tar.extractall(temp_path)

--- a/wikigr/packs/seed_researcher.py
+++ b/wikigr/packs/seed_researcher.py
@@ -680,19 +680,6 @@ Return JSON with this exact structure:
     # Private Methods: Scoring and Validation
     # ========================================================================
 
-    def _score_content(self, _url: str) -> float:
-        """Score article content quality (0.0-1.0).
-
-        Args:
-            url: URL to score
-
-        Returns:
-            Content quality score
-        """
-        # Simplified content scoring (could be enhanced)
-        # For now, return default score
-        return 0.8
-
     def _score_recency(self, published_date: str | None) -> float:
         """Score recency based on publication date.
 


### PR DESCRIPTION
## Summary
- **#175**: Removed dead `_score_content()` method from `seed_researcher.py` that returned hardcoded `0.8` and was never called anywhere. Zero-BS principle: every function must work or not exist.
- **#177**: Added symlink and hardlink rejection to tar extraction security checks in `distribution.py::unpackage_pack()`. A malicious archive could previously use symlinks to traverse outside the extraction directory.

## Changes
- `wikigr/packs/seed_researcher.py`: Deleted `_score_content()` (lines 683-694). The method was dead code — `rank_urls()` uses `url.content_score` from the `ExtractedURL` object, not this method.
- `wikigr/packs/distribution.py`: Added `member.issym()` and `member.islnk()` checks alongside existing path traversal checks.
- `tests/packs/test_distribution.py`: Added `test_unpackage_rejects_symlinks` and `test_unpackage_rejects_hardlinks` tests.

## Test plan
- [x] All 30 seed_researcher tests pass (no regressions from stub removal)
- [x] All 15 distribution tests pass (including 2 new symlink/hardlink tests)
- [x] Pre-commit checks pass (ruff, ruff-format, trailing whitespace, etc.)

Closes #175, closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)