### PR TITLE
Add logging to 5 swallowed exceptions

### DIFF
--- a/scripts/run_30k_llm.py
+++ b/scripts/run_30k_llm.py
@@ -58,7 +58,8 @@ def process_article_with_llm(title: str, conn, wiki_client, embedder, extractor,
             redirect_target = redirect_match.group(1).split("|")[0].strip()
             try:
                 article = wiki_client.fetch_article(redirect_target)
-            except Exception:
+            except Exception as e:
+                logger.warning("Cannot follow redirect '%s' -> '%s': %s", title, redirect_target, e)
                 return True  # Skip unfollowable redirects
 
         # Parse

--- a/scripts/run_30k_llm_parallel.py
+++ b/scripts/run_30k_llm_parallel.py
@@ -91,7 +91,10 @@ class ParallelLLMPipeline:
                 redirect_target = redirect_match.group(1).split("|")[0].strip()
                 try:
                     article = wiki_client.fetch_article(redirect_target)
-                except Exception:
+                except Exception as e:
+                    logger.warning(
+                        "Cannot follow redirect '%s' -> '%s': %s", title, redirect_target, e
+                    )
                     return None  # Skip
 
             # Parse

--- a/wikigr/agent/kg_agent.py
+++ b/wikigr/agent/kg_agent.py
@@ -1102,8 +1102,8 @@ Use $q as the default parameter name. Return ONLY the JSON, nothing else."""
                 )
                 df = result.get_as_df()
                 facts.extend(df["content"].dropna().tolist())
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("Failed to fetch facts for '%s': %s", title, e)
 
         return {
             "sources": source_titles,

--- a/wikigr/agent/seed_agent.py
+++ b/wikigr/agent/seed_agent.py
@@ -178,8 +178,8 @@ Return ONLY valid JSON:
                         "Anthropic API authentication failed. "
                         "Set ANTHROPIC_API_KEY or pass anthropic_api_key=."
                     ) from e
-            except ImportError:
-                pass
+            except ImportError as imp_err:
+                logger.debug("Optional import unavailable: %s", imp_err)
             logger.error(f"Failed to generate titles for '{topic}': {type(e).__name__}: {e}")
             return []
 

--- a/wikigr/packs/discovery.py
+++ b/wikigr/packs/discovery.py
@@ -4,11 +4,14 @@ This module provides functions to discover installed knowledge packs and
 validate their structure.
 """
 
+import logging
 from pathlib import Path
 
 from wikigr.packs.manifest import load_manifest
 from wikigr.packs.models import PackInfo
 from wikigr.packs.validator import validate_pack_structure
+
+logger = logging.getLogger(__name__)
 
 
 def is_valid_pack(pack_dir: Path) -> bool:
@@ -73,8 +76,8 @@ def discover_packs(packs_dir: Path = Path.home() / ".wikigr/packs") -> list[Pack
                 skill_path=skill_path.resolve(),  # Make absolute
             )
             packs.append(pack_info)
-        except Exception:
-            # Skip packs that fail to load
+        except Exception as e:
+            logger.warning("Failed to load pack from %s: %s", item, e)
             continue
 
     return packs


### PR DESCRIPTION
## Summary
- Replaces 5 bare `except: pass` / `except: continue` blocks with proper `logger.warning()` or `logger.debug()` calls so failures become visible during debugging
- Adds `import logging` and `logger = logging.getLogger(__name__)` to `wikigr/packs/discovery.py` (the other 4 files already had loggers)

Closes #178

## Changes

| File | Line | Was | Now |
|------|------|-----|-----|
| `wikigr/agent/kg_agent.py` | 1105 | `except Exception: pass` | `logger.debug("Failed to fetch facts for '%s': %s", title, e)` |
| `wikigr/agent/seed_agent.py` | 181 | `except ImportError: pass` | `logger.debug("Optional import unavailable: %s", imp_err)` |
| `wikigr/packs/discovery.py` | 76 | `except Exception: continue` | `logger.warning("Failed to load pack from %s: %s", item, e)` |
| `scripts/run_30k_llm.py` | 61 | `except Exception: return True` | `logger.warning("Cannot follow redirect '%s' -> '%s': %s", ...)` |
| `scripts/run_30k_llm_parallel.py` | 94 | `except Exception: return None` | `logger.warning("Cannot follow redirect '%s' -> '%s': %s", ...)` |

## Test plan
- [x] `ruff check` passes on all 5 files
- [x] `ruff format` passes on all 5 files
- [x] All pre-commit hooks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)