### PR TITLE
Add SSRF protection for pack downloads (#176)

### DIFF
--- a/tests/packs/test_url_validation.py
+++ b/tests/packs/test_url_validation.py
@@ -1,0 +1,81 @@
+"""Tests for SSRF protection in pack download URL validation."""
+
+from unittest.mock import patch
+
+import pytest
+
+from wikigr.packs._url_validation import validate_download_url
+
+
+class TestValidateDownloadUrl:
+    """Tests for validate_download_url()."""
+
+    def test_allows_https(self) -> None:
+        """HTTPS URLs with public hostnames should pass validation."""
+        # Mock DNS to return a public IP so we don't make real DNS queries
+        with patch(
+            "wikigr.packs._url_validation.socket.gethostbyname", return_value="93.184.216.34"
+        ):
+            validate_download_url("https://registry.wikigr.com/packs/test-1.0.tar.gz")
+
+    def test_rejects_http_scheme(self) -> None:
+        """HTTP (non-TLS) URLs must be rejected."""
+        with pytest.raises(ValueError, match="Only HTTPS URLs allowed"):
+            validate_download_url("http://example.com/pack.tar.gz")
+
+    def test_rejects_file_scheme(self) -> None:
+        """file:// URLs must be rejected to prevent local file exfiltration."""
+        with pytest.raises(ValueError, match="Only HTTPS URLs allowed"):
+            validate_download_url("file:///etc/passwd")
+
+    def test_rejects_ftp_scheme(self) -> None:
+        """ftp:// URLs must be rejected."""
+        with pytest.raises(ValueError, match="Only HTTPS URLs allowed"):
+            validate_download_url("ftp://files.example.com/pack.tar.gz")
+
+    def test_rejects_no_scheme(self) -> None:
+        """URLs without a scheme must be rejected."""
+        with pytest.raises(ValueError, match="Only HTTPS URLs allowed"):
+            validate_download_url("example.com/pack.tar.gz")
+
+    def test_rejects_empty_hostname(self) -> None:
+        """URLs without a hostname must be rejected."""
+        with pytest.raises(ValueError, match="URL must have a hostname"):
+            validate_download_url("https:///path/only")
+
+    def test_rejects_private_ip(self) -> None:
+        """URLs resolving to private IPs (e.g. 192.168.x.x) must be rejected."""
+        with (
+            patch("wikigr.packs._url_validation.socket.gethostbyname", return_value="192.168.1.1"),
+            pytest.raises(ValueError, match="private/reserved IPs not allowed"),
+        ):
+            validate_download_url("https://internal.corp/pack.tar.gz")
+
+    def test_rejects_loopback(self) -> None:
+        """URLs resolving to loopback (127.0.0.1) must be rejected."""
+        with (
+            patch("wikigr.packs._url_validation.socket.gethostbyname", return_value="127.0.0.1"),
+            pytest.raises(ValueError, match="private/reserved IPs not allowed"),
+        ):
+            validate_download_url("https://localhost/pack.tar.gz")
+
+    def test_rejects_link_local(self) -> None:
+        """URLs resolving to link-local IPs (169.254.x.x) must be rejected."""
+        with (
+            patch(
+                "wikigr.packs._url_validation.socket.gethostbyname", return_value="169.254.169.254"
+            ),
+            pytest.raises(ValueError, match="private/reserved IPs not allowed"),
+        ):
+            validate_download_url("https://metadata.internal/pack.tar.gz")
+
+    def test_dns_failure_allows_through(self) -> None:
+        """DNS resolution failure should not block — download will fail later."""
+        import socket
+
+        with patch(
+            "wikigr.packs._url_validation.socket.gethostbyname",
+            side_effect=socket.gaierror("Name resolution failed"),
+        ):
+            # Should not raise — DNS failure is handled gracefully
+            validate_download_url("https://nonexistent.example.com/pack.tar.gz")

--- a/wikigr/packs/_url_validation.py
+++ b/wikigr/packs/_url_validation.py
@@ -1,0 +1,36 @@
+"""URL validation for pack downloads -- SSRF prevention.
+
+Validates that download URLs use HTTPS and do not target private/reserved IPs.
+"""
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+
+def validate_download_url(url: str) -> None:
+    """Validate URL before download -- SSRF prevention.
+
+    Ensures the URL uses HTTPS and does not resolve to a private, reserved,
+    or loopback IP address.
+
+    Args:
+        url: The URL to validate.
+
+    Raises:
+        ValueError: If the URL scheme is not HTTPS, has no hostname,
+                    or resolves to a private/reserved/loopback IP.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("https",):
+        raise ValueError(f"Only HTTPS URLs allowed for downloads, got: {parsed.scheme!r}")
+    if not parsed.hostname:
+        raise ValueError("URL must have a hostname")
+
+    # Block private/reserved IPs
+    try:
+        resolved_ip = ipaddress.ip_address(socket.gethostbyname(parsed.hostname))
+        if resolved_ip.is_private or resolved_ip.is_reserved or resolved_ip.is_loopback:
+            raise ValueError(f"Downloads from private/reserved IPs not allowed: {resolved_ip}")
+    except socket.gaierror:
+        pass  # DNS resolution failure -- will fail at download time

--- a/wikigr/packs/installer.py
+++ b/wikigr/packs/installer.py
@@ -8,6 +8,7 @@ import tempfile
 import urllib.request
 from pathlib import Path
 
+from wikigr.packs._url_validation import validate_download_url
 from wikigr.packs.distribution import unpackage_pack
 from wikigr.packs.manifest import load_manifest
 from wikigr.packs.models import PackInfo
@@ -79,6 +80,9 @@ class PackInstaller:
             tmp_path = Path(tmp_file.name)
 
         try:
+            # Validate URL before download (SSRF prevention)
+            validate_download_url(url)
+
             # Download pack archive
             urllib.request.urlretrieve(url, tmp_path)
 

--- a/wikigr/packs/registry_api.py
+++ b/wikigr/packs/registry_api.py
@@ -12,6 +12,8 @@ import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 
+from wikigr.packs._url_validation import validate_download_url
+
 
 @dataclass
 class PackListing:
@@ -146,6 +148,9 @@ class PackRegistryClient:
         # Create temp file for download
         temp_dir = Path(tempfile.gettempdir())
         output_path = temp_dir / f"{name}-{version}.tar.gz"
+
+        # Validate URL before download (SSRF prevention)
+        validate_download_url(pack_info.download_url)
 
         # Download pack archive
         urllib.request.urlretrieve(pack_info.download_url, output_path)


### PR DESCRIPTION
## Summary

- Add `validate_download_url()` in `wikigr/packs/_url_validation.py` to prevent SSRF via `urlretrieve()` in `installer.py` and `registry_api.py`
- Enforces HTTPS-only scheme, rejects private/reserved/loopback IPs via DNS resolution check
- Called before every `urlretrieve()` call in both `PackInstaller.install_from_url()` and `PackRegistryClient.download_pack()`

Closes #176

## Changes

| File | Change |
|------|--------|
| `wikigr/packs/_url_validation.py` | New shared SSRF validation helper |
| `wikigr/packs/installer.py` | Call `validate_download_url()` before `urlretrieve()` (line 84) |
| `wikigr/packs/registry_api.py` | Call `validate_download_url()` before `urlretrieve()` (line 153) |
| `tests/packs/test_url_validation.py` | 10 tests covering all validation paths |

## Test plan

- [x] test_allows_https -- HTTPS with public IP passes
- [x] test_rejects_http_scheme -- HTTP blocked
- [x] test_rejects_file_scheme -- file:// blocked
- [x] test_rejects_ftp_scheme -- ftp:// blocked
- [x] test_rejects_no_scheme -- missing scheme blocked
- [x] test_rejects_empty_hostname -- empty hostname blocked
- [x] test_rejects_private_ip -- 192.168.x.x blocked
- [x] test_rejects_loopback -- 127.0.0.1 blocked
- [x] test_rejects_link_local -- 169.254.x.x blocked (AWS metadata endpoint)
- [x] test_dns_failure_allows_through -- DNS failure handled gracefully

All 10 tests passing, all pre-commit hooks passing (ruff, ruff-format, banned patterns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)