### PR TITLE
Fix Round 4 A-blockers and SHOULD-FIX quality issues

### DIFF
--- a/backend/api/v1/chat.py
+++ b/backend/api/v1/chat.py
@@ -160,8 +160,8 @@ def chat_stream(
             client = agent.claude
 
             with client.messages.stream(
-                model="claude-haiku-4-5-20251001",
-                max_tokens=512,
+                model=agent.synthesis_model,
+                max_tokens=agent.SYNTHESIS_MAX_TOKENS,
                 messages=[{"role": "user", "content": context}],
             ) as stream:
                 for text in stream.text_stream:

--- a/wikigr/agent/reranker.py
+++ b/wikigr/agent/reranker.py
@@ -101,7 +101,7 @@ class GraphReranker:
 
             if df.empty:
                 # No articles found in graph
-                return {aid: 0.0 for aid in article_ids}
+                return dict.fromkeys(article_ids, 0.0)
 
             # Normalize in Python to avoid Kuzu nested-aggregation errors
             max_degree = float(df["degree"].max()) if not df.empty else 0.0
@@ -121,7 +121,7 @@ class GraphReranker:
         except Exception as e:
             logger.error(f"Centrality calculation failed: {e}")
             # Fallback: all articles get zero centrality
-            return {aid: 0.0 for aid in article_ids}
+            return dict.fromkeys(article_ids, 0.0)
 
     def rerank(
         self,
@@ -181,7 +181,7 @@ class GraphReranker:
 
         # Calculate centrality scores (skip for sparse graphs to avoid degradation)
         if self._sparse_graph:
-            centrality = {aid: 0.0 for aid in article_ids}
+            centrality = dict.fromkeys(article_ids, 0.0)
         else:
             centrality = self.calculate_centrality(article_ids)
 

--- a/wikigr/cli.py
+++ b/wikigr/cli.py
@@ -510,7 +510,8 @@ def _get_db_stats(db_path: str) -> dict:
     try:
         result = conn.execute("MATCH (c:Category) RETURN COUNT(c) AS count")
         stats["categories"] = int(result.get_as_df().iloc[0]["count"])
-    except Exception:
+    except Exception as e:
+        logger.debug("Category count query failed: %s", e)
         stats["categories"] = 0
 
     del conn


### PR DESCRIPTION
## Summary
- Fix 2 A-BLOCKER issues: missing `synthesis_model` in `from_connection()` and hardcoded haiku model in streaming endpoint
- Fix 5 SHOULD-FIX issues: magic numbers extracted to constants, swallowed exception, redundant import, ruff C420 warnings, return type annotations

## Changes by file

### `wikigr/agent/kg_agent.py`
1. **A-BLOCKER**: Added `agent.synthesis_model = cls.DEFAULT_MODEL` to `from_connection()` -- was causing `AttributeError` at runtime when streaming endpoint used `agent.synthesis_model`
2. Added 6 class constants: `VECTOR_CONFIDENCE_THRESHOLD`, `PLAN_CACHE_MAX_SIZE`, `MAX_ARTICLE_CHARS`, `PLAN_MAX_TOKENS`, `SYNTHESIS_MAX_TOKENS`, `SEED_EXTRACT_MAX_TOKENS`
3. Replaced all hardcoded magic numbers at their usage sites with the new constants
4. Removed redundant `import re` inside `_direct_title_lookup` (already imported at module level)
5. Added return type annotations: `_hybrid_retrieve -> dict[str, Any]`, `close -> None`

### `backend/api/v1/chat.py`
6. **A-BLOCKER**: Changed `model="claude-haiku-4-5-20251001"` to `model=agent.synthesis_model` in streaming endpoint
7. Changed `max_tokens=512` to `max_tokens=agent.SYNTHESIS_MAX_TOKENS` for consistency

### `wikigr/cli.py`
8. Changed `except Exception:` to `except Exception as e: logger.debug(...)` to stop swallowing the category count query exception

### `wikigr/agent/reranker.py`
9. Fixed 3 ruff C420 warnings: `{k: 0.0 for k in ids}` -> `dict.fromkeys(ids, 0.0)`

## Test plan
- [x] `uv run pytest tests/agent/test_kg_agent_core.py` -- 28/28 passed
- [x] Full test suite: 366 passed, 14 failed (pre-existing DB-dependent tests), 4 skipped
- [x] `ruff check` -- all checks passed
- [x] Pre-commit hooks -- all passed