### PR TITLE
Fix hardcoded values across baselines, seed_agent, backend, and eval

### DIFF
--- a/backend/api/v1/articles.py
+++ b/backend/api/v1/articles.py
@@ -31,7 +31,7 @@ router = APIRouter(prefix="/api/v1", tags=["articles"])
         500: {"model": ErrorResponse},
     },
 )
-@limiter.limit("30/minute")
+@limiter.limit(settings.articles_rate_limit)
 def get_article(
     request: Request,  # noqa: ARG001 - required by slowapi limiter
     response: Response,
@@ -43,8 +43,7 @@ def get_article(
 
     Returns article metadata, sections, links, and backlinks.
     """
-    # Set cache headers
-    response.headers["Cache-Control"] = "public, max-age=86400"
+    response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_article}"
 
     try:
         result = ArticleService.get_article_details(conn=conn, title=title)
@@ -82,7 +81,7 @@ def get_article(
     response_model=CategoryListResponse,
     responses={500: {"model": ErrorResponse}},
 )
-@limiter.limit("30/minute")
+@limiter.limit(settings.articles_rate_limit)
 def get_categories(
     request: Request,  # noqa: ARG001 - required by slowapi limiter
     response: Response,
@@ -93,8 +92,7 @@ def get_categories(
 
     Returns categories sorted by article count (descending).
     """
-    # Set cache headers
-    response.headers["Cache-Control"] = "public, max-age=3600"
+    response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_default}"
 
     try:
         result = ArticleService.get_categories(conn=conn)
@@ -119,7 +117,7 @@ def get_categories(
     response_model=StatsResponse,
     responses={500: {"model": ErrorResponse}},
 )
-@limiter.limit("30/minute")
+@limiter.limit(settings.articles_rate_limit)
 def get_stats(
     request: Request,  # noqa: ARG001 - required by slowapi limiter
     response: Response,
@@ -130,8 +128,7 @@ def get_stats(
 
     Returns comprehensive statistics about articles, sections, links, and performance.
     """
-    # Set cache headers
-    response.headers["Cache-Control"] = "public, max-age=300"
+    response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_stats}"
 
     try:
         result = ArticleService.get_stats(conn=conn, db_path=settings.database_path)

--- a/backend/api/v1/chat.py
+++ b/backend/api/v1/chat.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import JSONResponse
 from sse_starlette.sse import EventSourceResponse
 
+from backend.config import settings
 from backend.db import get_db
 from backend.models.chat import ChatRequest, ChatResponse
 from backend.rate_limit import limiter
@@ -45,7 +46,7 @@ def _get_anthropic_client():
         503: {"description": "Agent unavailable (missing API key or DB)"},
     },
 )
-@limiter.limit("5/minute")
+@limiter.limit(settings.chat_rate_limit)
 def chat(
     request_body: ChatRequest,
     request: Request,  # noqa: ARG001 - required by slowapi limiter
@@ -109,7 +110,7 @@ def chat(
 
 
 @router.get("/chat/stream")
-@limiter.limit("5/minute")
+@limiter.limit(settings.chat_rate_limit)
 def chat_stream(
     request: Request,  # noqa: ARG001 - required by slowapi limiter
     question: str = Query(..., max_length=500),

--- a/backend/api/v1/graph.py
+++ b/backend/api/v1/graph.py
@@ -11,6 +11,7 @@ import kuzu
 from fastapi import APIRouter, Depends, Query, Request, Response
 from fastapi.responses import JSONResponse
 
+from backend.config import settings
 from backend.db import get_db
 from backend.models.common import ErrorResponse
 from backend.models.graph import GraphResponse
@@ -31,7 +32,7 @@ router = APIRouter(prefix="/api/v1", tags=["graph"])
         500: {"model": ErrorResponse},
     },
 )
-@limiter.limit("20/minute")
+@limiter.limit(settings.graph_rate_limit)
 def get_graph(
     request: Request,  # noqa: ARG001 - required by slowapi limiter
     response: Response,
@@ -46,8 +47,7 @@ def get_graph(
 
     Returns nodes and edges within specified depth from seed article.
     """
-    # Set cache headers
-    response.headers["Cache-Control"] = "public, max-age=3600"
+    response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_default}"
 
     try:
         result = GraphService.get_graph_neighbors(

--- a/backend/api/v1/hybrid.py
+++ b/backend/api/v1/hybrid.py
@@ -11,6 +11,7 @@ import kuzu
 from fastapi import APIRouter, Depends, Query, Request, Response
 from fastapi.responses import JSONResponse
 
+from backend.config import settings
 from backend.db import get_db
 from backend.models.common import ErrorResponse
 from backend.models.search import SearchResponse, SearchResult
@@ -30,7 +31,7 @@ router = APIRouter(prefix="/api/v1", tags=["search"])
         500: {"model": ErrorResponse},
     },
 )
-@limiter.limit("10/minute")
+@limiter.limit(settings.hybrid_rate_limit)
 def hybrid_search(
     request: Request,  # noqa: ARG001 - required by slowapi limiter
     response: Response,
@@ -48,7 +49,7 @@ def hybrid_search(
     """
     import time
 
-    response.headers["Cache-Control"] = "public, max-age=3600"
+    response.headers["Cache-Control"] = f"public, max-age={settings.cache_ttl_default}"
     start = time.perf_counter()
 
     try:

--- a/backend/config.py
+++ b/backend/config.py
@@ -34,6 +34,19 @@ class Settings(BaseSettings):
     # Database Settings
     database_path: str = ""
 
+    # Rate Limits (requests per minute)
+    chat_rate_limit: str = "5/minute"
+    search_rate_limit: str = "10/minute"
+    autocomplete_rate_limit: str = "60/minute"
+    articles_rate_limit: str = "30/minute"
+    graph_rate_limit: str = "20/minute"
+    hybrid_rate_limit: str = "10/minute"
+
+    # Cache TTLs (seconds)
+    cache_ttl_default: int = 3600  # 1 hour — search, autocomplete, graph, categories, hybrid
+    cache_ttl_article: int = 86400  # 24 hours — individual article detail
+    cache_ttl_stats: int = 300  # 5 minutes — database statistics
+
     model_config = {"env_prefix": "WIKIGR_"}
 
 

--- a/tests/packs/eval/test_baselines.py
+++ b/tests/packs/eval/test_baselines.py
@@ -34,7 +34,7 @@ def mock_anthropic_response() -> Mock:
 def test_training_baseline_evaluator_init():
     """Test TrainingBaselineEvaluator initialization."""
     evaluator = TrainingBaselineEvaluator(api_key="test_key")
-    assert evaluator.model == "claude-sonnet-4-5-20250929"
+    assert evaluator.model == "claude-opus-4-6"
 
 
 @patch("wikigr.packs.eval.baselines.Anthropic")
@@ -68,7 +68,7 @@ def test_knowledge_pack_evaluator_init(tmp_path: Path):
 
     evaluator = KnowledgePackEvaluator(pack_path, api_key="test_key")
     assert evaluator.pack_path == pack_path
-    assert evaluator.model == "claude-sonnet-4-5-20250929"
+    assert evaluator.model == "claude-opus-4-6"
 
 
 @patch("wikigr.packs.eval.baselines.Anthropic")

--- a/wikigr/agent/seed_agent.py
+++ b/wikigr/agent/seed_agent.py
@@ -41,7 +41,7 @@ class SeedAgent:
     def __init__(
         self,
         anthropic_api_key: str | None = None,
-        model: str = "claude-haiku-4-5-20251001",
+        model: str = "claude-opus-4-6",
         seeds_per_topic: int = 10,
         wikipedia_client: WikipediaAPIClient | None = None,
     ):

--- a/wikigr/packs/eval/baselines.py
+++ b/wikigr/packs/eval/baselines.py
@@ -13,6 +13,11 @@ from anthropic import Anthropic
 
 from wikigr.packs.eval.models import Answer, Question
 
+# Model and pricing constants (Opus 4.6)
+DEFAULT_MODEL = "claude-opus-4-6"
+INPUT_COST_PER_MTOK = 15  # USD per million input tokens
+OUTPUT_COST_PER_MTOK = 75  # USD per million output tokens
+
 
 class TrainingBaselineEvaluator:
     """Evaluate using Claude without any tools (training data only).
@@ -28,7 +33,7 @@ class TrainingBaselineEvaluator:
             api_key: Anthropic API key (uses ANTHROPIC_API_KEY env var if not provided)
         """
         self.client = Anthropic(api_key=api_key)
-        self.model = "claude-sonnet-4-5-20250929"
+        self.model = DEFAULT_MODEL
 
     def evaluate(self, questions: list[Question]) -> list[Answer]:
         """Evaluate questions using only training data.
@@ -55,10 +60,11 @@ class TrainingBaselineEvaluator:
             # Extract answer text
             answer_text = response.content[0].text if response.content else ""
 
-            # Estimate cost (Sonnet 3.5: $3/MTok input, $15/MTok output)
             input_tokens = response.usage.input_tokens
             output_tokens = response.usage.output_tokens
-            cost_usd = (input_tokens * 3 + output_tokens * 15) / 1_000_000
+            cost_usd = (
+                input_tokens * INPUT_COST_PER_MTOK + output_tokens * OUTPUT_COST_PER_MTOK
+            ) / 1_000_000
 
             answers.append(
                 Answer(
@@ -89,7 +95,7 @@ class KnowledgePackEvaluator:
         """
         self.pack_path = pack_path
         self.client = Anthropic(api_key=api_key)
-        self.model = "claude-sonnet-4-5-20250929"
+        self.model = DEFAULT_MODEL
 
     def _retrieve_context(self, question: str) -> str:
         """Retrieve relevant context from knowledge pack.
@@ -170,10 +176,11 @@ Provide a comprehensive answer with references to the context."""
 
             answer_text = response.content[0].text if response.content else ""
 
-            # Estimate cost
             input_tokens = response.usage.input_tokens
             output_tokens = response.usage.output_tokens
-            cost_usd = (input_tokens * 3 + output_tokens * 15) / 1_000_000
+            cost_usd = (
+                input_tokens * INPUT_COST_PER_MTOK + output_tokens * OUTPUT_COST_PER_MTOK
+            ) / 1_000_000
 
             answers.append(
                 Answer(


### PR DESCRIPTION
## Summary
- Extract `DEFAULT_MODEL`, `INPUT_COST_PER_MTOK`, and `OUTPUT_COST_PER_MTOK` constants in `baselines.py` — fixes duplicated model string and corrects stale Sonnet 3.5 pricing to Opus 4.6 ($15/$75 per MTok)
- Change `seed_agent.py` default model from `claude-haiku-4-5-20251001` to `claude-opus-4-6` to match kg_agent
- Add rate limit and cache TTL settings to `backend/config.py` Settings class; update all 5 endpoint files (`chat.py`, `search.py`, `articles.py`, `graph.py`, `hybrid.py`) to use `settings.*` instead of hardcoded strings
- Add `--pack` CLI argument to `run_enhancement_evaluation.py` (default: `physics-expert`), extract `JUDGE_MODEL` constant, thread `pack_dir` through all functions
- Update test assertions to match new `DEFAULT_MODEL`

## Test plan
- [x] All 298 packs tests pass (`tests/packs/`)
- [x] All 17 seed_agent tests pass (`tests/agent/test_seed*`)
- [x] Syntax validation passes for all 10 changed files
- [x] Pre-commit hooks pass (ruff, ruff-format, trim-whitespace, etc.)
- [x] 425 other tests pass (9 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)