### PR TITLE
Experiment 5: Enriched synthesis prompt with structured context

### DIFF
--- a/tests/agent/test_kg_agent_core.py
+++ b/tests/agent/test_kg_agent_core.py
@@ -354,11 +354,12 @@ class TestBuildSynthesisContext:
             )
 
         assert "What is quantum mechanics?" in context
-        assert "Quantum Mechanics" in context
+        assert "## Retrieved Article Content" in context
+        assert "## Quantum" in context  # source text within article section
         assert "Planck" in context
+        assert "## Extracted Facts" in context
         assert "Energy is quantized" in context
         assert "Photons have wave-particle duality" in context
-        assert "## Quantum" in context  # source text section
 
     def test_includes_few_shot_examples(self) -> None:
         agent = _make_agent()
@@ -391,8 +392,12 @@ class TestBuildSynthesisContext:
                 query_plan={"type": "fact_retrieval", "cypher": "MATCH (a) RETURN a"},
             )
 
-        # When enriched_context is present, it should be used instead of standard context
+        # When enriched_context is present and no source_text, it goes under article content
+        assert "## Retrieved Article Content" in context
         assert "Multi-doc enriched context block here." in context
+        # Facts should appear under their own section
+        assert "## Extracted Facts" in context
+        assert "Dark matter makes up 27%" in context
         # Standard context (Cypher line) should NOT appear
         assert "Cypher:" not in context
 
@@ -405,9 +410,9 @@ class TestBuildSynthesisContext:
                 query_plan={"type": "entity_search", "cypher": "MATCH (a) RETURN a"},
             )
 
-        # Should still produce a valid prompt string
+        # Should still produce a valid prompt with the empty-context fallback
         assert "What is nothing?" in context
-        assert "Sources:" in context
+        assert "(No relevant content retrieved)" in context
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
- Replace flat context format (Query Type/Cypher/Sources/Raw results) with structured sections (`## Retrieved Article Content`, `## Extracted Facts`, `## Related Entities`) to help Claude better leverage retrieved content
- Add explicit instruction to never refuse answering -- always fall back to own knowledge when KG content is limited
- Remove internal Cypher query details from the synthesis prompt (Claude doesn't need to see the query internals)

## Hypothesis
Even when good content IS retrieved, the synthesis prompt doesn't present it optimally. The current prompt lists "Sources: title1, title2" and "Facts: - fact1" but the actual article text is sometimes missing or buried. A richer, more structured prompt with clear section headers should help Claude produce better answers.

## Key Changes
1. Clear section headers (`## Retrieved Article Content`, `## Extracted Facts`, `## Related Entities`)
2. Explicit instruction to NEVER refuse to answer -- always use own knowledge as fallback
3. Prioritize article content over raw Cypher results
4. Remove confusing "Query Type: ..." and "Cypher: ..." from the prompt
5. Increase fact limit from 10 to 15

## Test plan
- [x] All 28 unit tests pass (test_kg_agent_core.py)
- [x] Ruff lint + format pass
- [ ] All-packs evaluation running (--sample 5, --disable-fewshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)