### PR TITLE
Fix FewShotManager to support JSONL format

### DIFF
--- a/wikigr/agent/few_shot.py
+++ b/wikigr/agent/few_shot.py
@@ -46,7 +46,12 @@ class FewShotManager:
             raise FileNotFoundError(f"Examples file not found: {self.examples_path}")
 
         with open(self.examples_path) as f:
-            self.examples = json.load(f)
+            # Support both JSON array and JSONL (one object per line) formats
+            content = f.read().strip()
+            if content.startswith("["):
+                self.examples = json.loads(content)
+            else:
+                self.examples = [json.loads(line) for line in content.splitlines() if line.strip()]
 
         # Security: Validate example count to prevent OOM
         if len(self.examples) > 1000:


### PR DESCRIPTION
Fixes crash when _resolve_few_shot_path points to eval/questions.jsonl (JSONL) instead of .json (array). Auto-detects format.