### PR TITLE
Add 10 AI/agentic coding knowledge packs

### DIFF
--- a/.github/workflows/pack-freshness.yml
+++ b/.github/workflows/pack-freshness.yml
@@ -1,0 +1,372 @@
+name: Pack Freshness Check
+
+on:
+  schedule:
+    # Weekly on Mondays at 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      pack:
+        description: "Pack name to check (leave empty for all packs)"
+        required: false
+        type: string
+      content_hash:
+        description: "Use content hashing instead of header comparison"
+        required: false
+        type: boolean
+        default: false
+      threshold:
+        description: "Change ratio threshold to trigger rebuild (0.0-1.0)"
+        required: false
+        type: string
+        default: "0.20"
+      skip_rebuild:
+        description: "Only check freshness, do not rebuild"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: pack-freshness-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.11"
+
+jobs:
+  # --------------------------------------------------------------------------
+  # Stage 1: Check URL freshness for all (or specified) packs
+  # --------------------------------------------------------------------------
+  check-freshness:
+    name: Check URL Freshness
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      packs_to_rebuild: ${{ steps.check.outputs.packs_to_rebuild }}
+      report_json: ${{ steps.check.outputs.report_json }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - run: uv python install ${{ env.PYTHON_VERSION }}
+
+      - run: uv venv && uv pip install requests
+
+      - name: Check freshness
+        id: check
+        run: |
+          ARGS=""
+          if [ -n "${{ inputs.pack }}" ]; then
+            ARGS="data/packs/${{ inputs.pack }}"
+          else
+            ARGS="--all"
+          fi
+
+          if [ "${{ inputs.content_hash }}" = "true" ]; then
+            ARGS="$ARGS --content-hash"
+          fi
+
+          THRESHOLD="${{ inputs.threshold }}"
+          THRESHOLD="${THRESHOLD:-0.20}"
+          ARGS="$ARGS --threshold $THRESHOLD --json"
+
+          echo "Running: uv run python scripts/check_pack_freshness.py $ARGS"
+          uv run python scripts/check_pack_freshness.py $ARGS > freshness_report.json || true
+
+          cat freshness_report.json
+
+          # Extract packs needing rebuild
+          PACKS_TO_REBUILD=$(
+            python3 -c "
+          import json, sys
+          with open('freshness_report.json') as f:
+              reports = json.load(f)
+          rebuilds = [r['pack_name'] for r in reports if r['needs_rebuild']]
+          print(json.dumps(rebuilds))
+          "
+          )
+          echo "Packs needing rebuild: $PACKS_TO_REBUILD"
+          echo "packs_to_rebuild=$PACKS_TO_REBUILD" >> "$GITHUB_OUTPUT"
+
+          # Store full report for later jobs
+          REPORT_JSON=$(cat freshness_report.json | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin)))")
+          echo "report_json=$REPORT_JSON" >> "$GITHUB_OUTPUT"
+
+      - name: Upload freshness report
+        uses: actions/upload-artifact@v4
+        with:
+          name: freshness-report
+          path: freshness_report.json
+          retention-days: 30
+
+  # --------------------------------------------------------------------------
+  # Stage 2: Rebuild packs that have changed (matrix strategy)
+  # --------------------------------------------------------------------------
+  rebuild-pack:
+    name: Rebuild ${{ matrix.pack }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    needs: check-freshness
+    if: |
+      needs.check-freshness.outputs.packs_to_rebuild != '[]' &&
+      inputs.skip_rebuild != true
+    strategy:
+      fail-fast: false
+      matrix:
+        pack: ${{ fromJson(needs.check-freshness.outputs.packs_to_rebuild) }}
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - run: uv python install ${{ env.PYTHON_VERSION }}
+
+      - run: uv venv && uv pip install -e ".[dev]"
+
+      - name: Rebuild pack
+        run: |
+          PACK="${{ matrix.pack }}"
+          SCRIPT="scripts/build_${PACK//-/_}_pack.py"
+
+          if [ ! -f "$SCRIPT" ]; then
+            echo "No build script found at $SCRIPT, skipping"
+            exit 0
+          fi
+
+          echo "Rebuilding $PACK using $SCRIPT --test-mode"
+          uv run python "$SCRIPT" --test-mode
+
+      - name: Upload rebuilt pack
+        uses: actions/upload-artifact@v4
+        with:
+          name: rebuilt-pack-${{ matrix.pack }}
+          path: |
+            data/packs/${{ matrix.pack }}/pack.db/
+            data/packs/${{ matrix.pack }}/manifest.json
+            data/packs/${{ matrix.pack }}/.freshness_cache.json
+          retention-days: 7
+
+  # --------------------------------------------------------------------------
+  # Stage 3: Quick eval on rebuilt packs
+  # --------------------------------------------------------------------------
+  eval-pack:
+    name: Eval ${{ matrix.pack }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [check-freshness, rebuild-pack]
+    if: |
+      needs.check-freshness.outputs.packs_to_rebuild != '[]' &&
+      inputs.skip_rebuild != true
+    strategy:
+      fail-fast: false
+      matrix:
+        pack: ${{ fromJson(needs.check-freshness.outputs.packs_to_rebuild) }}
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - run: uv python install ${{ env.PYTHON_VERSION }}
+
+      - run: uv venv && uv pip install -e ".[dev]"
+
+      - name: Download rebuilt pack
+        uses: actions/download-artifact@v4
+        with:
+          name: rebuilt-pack-${{ matrix.pack }}
+          path: data/packs/${{ matrix.pack }}/
+
+      - name: Run quick eval (5 questions)
+        run: |
+          PACK="${{ matrix.pack }}"
+          QUESTIONS_FILE="data/packs/${PACK}/eval/questions.json"
+
+          if [ ! -f "$QUESTIONS_FILE" ]; then
+            echo "No eval questions found at $QUESTIONS_FILE, skipping"
+            exit 0
+          fi
+
+          echo "Running eval for $PACK (5 questions)"
+          uv run python -c "
+          import json, sys
+          from pathlib import Path
+          from wikigr.packs.eval.runner import EvalRunner
+          from wikigr.packs.eval.models import Question
+
+          pack_path = Path('data/packs/${PACK}')
+          questions_path = pack_path / 'eval/questions.json'
+
+          with open(questions_path) as f:
+              raw = json.load(f)
+
+          questions = [
+              Question(
+                  id=q['id'],
+                  question=q['question'],
+                  ground_truth=q['ground_truth'],
+                  domain=q['domain'],
+                  difficulty=q['difficulty'],
+              )
+              for q in raw[:5]  # Quick sanity: 5 questions only
+          ]
+
+          runner = EvalRunner(pack_path)
+          result = runner.run_evaluation(questions)
+          runner.save_results(result, pack_path / 'eval/freshness_eval.json')
+
+          print(f'Eval complete: accuracy={result.knowledge_pack.accuracy:.2f}')
+          print(f'Surpasses training: {result.surpasses_training}')
+          "
+
+      - name: Upload eval results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: eval-results-${{ matrix.pack }}
+          path: data/packs/${{ matrix.pack }}/eval/freshness_eval.json
+          retention-days: 30
+
+  # --------------------------------------------------------------------------
+  # Stage 4: Create PR with updated packs
+  # --------------------------------------------------------------------------
+  create-pr:
+    name: Create Update PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [check-freshness, rebuild-pack, eval-pack]
+    if: |
+      always() &&
+      needs.check-freshness.outputs.packs_to_rebuild != '[]' &&
+      needs.rebuild-pack.result == 'success' &&
+      inputs.skip_rebuild != true
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all rebuilt packs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: rebuilt-pack-*
+          merge-multiple: true
+          path: data/packs/
+
+      - name: Download freshness report
+        uses: actions/download-artifact@v4
+        with:
+          name: freshness-report
+          path: .
+
+      - name: Download eval results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: eval-results-*
+          merge-multiple: true
+          path: eval-results/
+        continue-on-error: true
+
+      - name: Generate freshness report body
+        id: report
+        run: |
+          python3 -c "
+          import json
+          from pathlib import Path
+
+          with open('freshness_report.json') as f:
+              reports = json.load(f)
+
+          rebuilds = [r for r in reports if r['needs_rebuild']]
+          if not rebuilds:
+              print('No packs needed rebuilding.')
+              exit(0)
+
+          lines = ['## Pack Freshness Report', '']
+          lines.append(f'**Checked at:** {reports[0][\"checked_at\"]}')
+          lines.append(f'**Packs checked:** {len(reports)}')
+          lines.append(f'**Packs rebuilt:** {len(rebuilds)}')
+          lines.append('')
+          lines.append('| Pack | Changed | Total | Ratio | Status |')
+          lines.append('|------|---------|-------|-------|--------|')
+
+          for r in reports:
+              status = 'Rebuilt' if r['needs_rebuild'] else 'OK'
+              lines.append(
+                  f'| {r[\"pack_name\"]} | {len(r[\"changed_urls\"])} '
+                  f'| {r[\"checked\"]} | {r[\"change_ratio\"]:.0%} | {status} |'
+              )
+
+          lines.append('')
+          lines.append('### Changed URLs')
+          for r in rebuilds:
+              lines.append(f'')
+              lines.append(f'**{r[\"pack_name\"]}:**')
+              for url in r['changed_urls']:
+                  lines.append(f'- {url}')
+
+          # Add eval results if available
+          eval_dir = Path('eval-results')
+          if eval_dir.exists():
+              eval_files = list(eval_dir.rglob('freshness_eval.json'))
+              if eval_files:
+                  lines.append('')
+                  lines.append('### Eval Results')
+                  lines.append('| Pack | Accuracy | Surpasses Training |')
+                  lines.append('|------|----------|-------------------|')
+                  for ef in eval_files:
+                      with open(ef) as f:
+                          ev = json.load(f)
+                      lines.append(
+                          f'| {ev[\"pack_name\"]} '
+                          f'| {ev[\"knowledge_pack\"][\"accuracy\"]:.2f} '
+                          f'| {ev[\"surpasses_training\"]} |'
+                      )
+
+          body = '\n'.join(lines)
+          # Write to file for the PR body
+          with open('pr_body.md', 'w') as f:
+              f.write(body)
+          print(body)
+          "
+
+      - name: Create branch and PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PACKS_JSON='${{ needs.check-freshness.outputs.packs_to_rebuild }}'
+          PACK_LIST=$(echo "$PACKS_JSON" | python3 -c "import json,sys; print(', '.join(json.load(sys.stdin)))")
+          BRANCH="auto/pack-freshness-$(date +%Y%m%d)"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+
+          # Add updated pack files (manifests + freshness caches, NOT .db files)
+          git add data/packs/*/.freshness_cache.json || true
+          git add data/packs/*/manifest.json || true
+
+          # Check if there are changes to commit
+          if git diff --cached --quiet; then
+            echo "No file changes to commit"
+            exit 0
+          fi
+
+          git commit -m "chore: update pack freshness data for $PACK_LIST
+
+          Automated freshness check detected content changes in source URLs.
+          Updated freshness caches and manifests for affected packs.
+
+          Packs updated: $PACK_LIST"
+
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "chore: pack freshness update ($PACK_LIST)" \
+            --body-file pr_body.md \
+            --label "automated,pack-freshness"

--- a/docs/pack-freshness-ci.md
+++ b/docs/pack-freshness-ci.md
@@ -1,0 +1,148 @@
+# Pack Freshness CI
+
+Automated system for detecting stale knowledge packs and rebuilding them when
+source URLs change.
+
+## How It Works
+
+The pipeline has four stages:
+
+```
+1. Check Freshness   -->  2. Rebuild Changed  -->  3. Quick Eval  -->  4. Create PR
+   (HEAD requests)        (build scripts)          (5 questions)       (manifest + cache)
+```
+
+### Stage 1: Check URL Freshness
+
+For every pack with a `urls.txt`, the system sends HTTP HEAD requests and
+compares `ETag` and `Last-Modified` headers against values stored in
+`.freshness_cache.json`. If the headers differ from the cached values, the URL
+is marked as changed.
+
+When more than 20% of a pack's URLs have changed, the pack is flagged for
+rebuild.
+
+### Stage 2: Rebuild
+
+Each flagged pack is rebuilt in parallel using its existing
+`scripts/build_{pack}_pack.py --test-mode` script. The matrix strategy means
+multiple packs rebuild concurrently.
+
+### Stage 3: Quick Eval
+
+A 5-question sanity eval runs against each rebuilt pack using the existing eval
+framework (`wikigr.packs.eval.runner`). This catches regressions before the PR
+is created.
+
+### Stage 4: PR Creation
+
+Updated `.freshness_cache.json` and `manifest.json` files are committed to an
+auto-generated branch and a PR is created with a freshness report table.
+
+## Schedule
+
+- **Automatic**: Runs every Monday at 06:00 UTC via cron
+- **Manual**: Trigger via GitHub UI or CLI
+
+## Manual Trigger
+
+Check a single pack:
+
+```bash
+gh workflow run pack-freshness.yml -f pack=kubernetes-networking
+```
+
+Check all packs without rebuilding:
+
+```bash
+gh workflow run pack-freshness.yml -f skip_rebuild=true
+```
+
+Use content hashing for more accuracy (slower):
+
+```bash
+gh workflow run pack-freshness.yml -f content_hash=true -f pack=rust-expert
+```
+
+Custom change threshold:
+
+```bash
+gh workflow run pack-freshness.yml -f threshold=0.10
+```
+
+## Local Usage
+
+The freshness script works standalone:
+
+```bash
+# Check a single pack
+python scripts/check_pack_freshness.py data/packs/kubernetes-networking
+
+# Check all packs
+python scripts/check_pack_freshness.py --all
+
+# JSON output for scripting
+python scripts/check_pack_freshness.py --all --json
+
+# Content hashing (downloads full pages)
+python scripts/check_pack_freshness.py data/packs/rust-expert --content-hash
+
+# Custom threshold (10% instead of default 20%)
+python scripts/check_pack_freshness.py --all --threshold 0.10
+```
+
+Exit codes:
+- `0`: No packs need rebuilding
+- `1`: At least one pack needs rebuilding
+
+## Freshness Cache
+
+Each pack stores header metadata in `data/packs/{name}/.freshness_cache.json`:
+
+```json
+{
+  "https://kubernetes.io/docs/concepts/services-networking/service/": {
+    "etag": "\"abc123\"",
+    "last_modified": "Mon, 15 Jan 2026 10:00:00 GMT",
+    "checked_at": "2026-02-28T06:00:00Z"
+  }
+}
+```
+
+This file is committed to the repo so the cache persists across CI runs (GitHub
+Actions has no persistent state beyond git).
+
+The first run for a pack always reports zero changes since there is nothing to
+compare against. Subsequent runs detect drift.
+
+## Rate Limiting
+
+The checker handles rate limiting:
+
+- 429 responses trigger exponential backoff (1s, 2s, 4s)
+- After max retries, rate-limited URLs are assumed unchanged (not a false positive)
+- Default concurrency is 8 workers per pack
+
+## Threshold Tuning
+
+The `--threshold` parameter controls what ratio of changed URLs triggers a
+rebuild. Default is 0.20 (20%).
+
+- **0.10**: Aggressive -- rebuilds on 10% change. Good for fast-moving domains
+- **0.20**: Balanced -- the default
+- **0.50**: Conservative -- only rebuilds when half the URLs changed
+
+## Required Secrets
+
+The workflow requires these repository secrets:
+
+- `ANTHROPIC_API_KEY`: For LLM-based pack building and evaluation
+
+## File Layout
+
+```
+scripts/check_pack_freshness.py          # Freshness checker CLI
+.github/workflows/pack-freshness.yml     # GitHub Actions workflow
+data/packs/{name}/.freshness_cache.json  # Per-pack header cache (committed)
+docs/pack-freshness-ci.md               # This file
+```

--- a/scripts/check_pack_freshness.py
+++ b/scripts/check_pack_freshness.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Check knowledge pack URL freshness by comparing HTTP headers against cached values.
+
+Sends HEAD requests to every URL in a pack's urls.txt, compares ETag and
+Last-Modified headers against a local freshness cache, and reports which URLs
+have changed since the last check.
+
+Usage:
+    # Check one pack
+    python scripts/check_pack_freshness.py data/packs/kubernetes-networking
+
+    # Check all packs, output JSON summary
+    python scripts/check_pack_freshness.py --all --json
+
+    # Check with content hashing (slower, more accurate)
+    python scripts/check_pack_freshness.py data/packs/rust-expert --content-hash
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CACHE_FILENAME = ".freshness_cache.json"
+USER_AGENT = "WikiGR-FreshnessChecker/1.0"
+DEFAULT_TIMEOUT = 15
+DEFAULT_WORKERS = 8
+MAX_RETRIES = 2
+CHANGE_THRESHOLD = 0.20  # 20 % of URLs must change to trigger rebuild
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class URLStatus:
+    url: str
+    status_code: int
+    etag: str | None
+    last_modified: str | None
+    content_hash: str | None
+    changed: bool
+    error: str | None
+
+
+@dataclass
+class PackFreshnessReport:
+    pack_name: str
+    pack_dir: str
+    total_urls: int
+    checked: int
+    changed_urls: list[str]
+    errored_urls: list[str]
+    change_ratio: float
+    needs_rebuild: bool
+    checked_at: str
+    details: list[URLStatus] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Cache I/O
+# ---------------------------------------------------------------------------
+
+
+def load_cache(pack_dir: Path) -> dict:
+    """Load the freshness cache for a pack. Returns empty dict on missing/corrupt file."""
+    cache_path = pack_dir / CACHE_FILENAME
+    if not cache_path.exists():
+        return {}
+    try:
+        with open(cache_path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def save_cache(pack_dir: Path, cache: dict) -> None:
+    """Persist freshness cache to disk."""
+    cache_path = pack_dir / CACHE_FILENAME
+    with open(cache_path, "w") as f:
+        json.dump(cache, f, indent=2)
+        f.write("\n")
+
+
+# ---------------------------------------------------------------------------
+# URL loading (reuses convention from existing build scripts)
+# ---------------------------------------------------------------------------
+
+
+def load_urls(urls_file: Path) -> list[str]:
+    """Load URLs from a pack's urls.txt, skipping comments and blanks."""
+    if not urls_file.exists():
+        return []
+    with open(urls_file) as f:
+        return [
+            line.strip()
+            for line in f
+            if line.strip() and not line.strip().startswith("#") and line.strip().startswith("http")
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Single-URL freshness check
+# ---------------------------------------------------------------------------
+
+
+def check_url(
+    url: str,
+    cached_entry: dict,
+    content_hash: bool = False,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> URLStatus:
+    """Send a HEAD (or GET for content hashing) request and compare against cache."""
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            if content_hash:
+                resp = requests.get(
+                    url,
+                    timeout=timeout,
+                    headers={"User-Agent": USER_AGENT},
+                    allow_redirects=True,
+                )
+            else:
+                resp = requests.head(
+                    url,
+                    timeout=timeout,
+                    headers={"User-Agent": USER_AGENT},
+                    allow_redirects=True,
+                )
+
+            if resp.status_code == 429:
+                # Rate limited -- back off, treat as unchanged if last attempt
+                if attempt < MAX_RETRIES:
+                    time.sleep(2**attempt)
+                    continue
+                return URLStatus(
+                    url=url,
+                    status_code=200,
+                    etag=cached_entry.get("etag"),
+                    last_modified=cached_entry.get("last_modified"),
+                    content_hash=cached_entry.get("content_hash"),
+                    changed=False,
+                    error="rate-limited, assumed unchanged",
+                )
+
+            if resp.status_code >= 400:
+                return URLStatus(
+                    url=url,
+                    status_code=resp.status_code,
+                    etag=None,
+                    last_modified=None,
+                    content_hash=None,
+                    changed=False,
+                    error=f"HTTP {resp.status_code}",
+                )
+
+            etag = resp.headers.get("ETag")
+            last_mod = resp.headers.get("Last-Modified")
+            c_hash = None
+            if content_hash and resp.status_code == 200:
+                c_hash = hashlib.sha256(resp.content).hexdigest()
+
+            # Determine if changed
+            changed = _is_changed(cached_entry, etag, last_mod, c_hash)
+
+            return URLStatus(
+                url=url,
+                status_code=resp.status_code,
+                etag=etag,
+                last_modified=last_mod,
+                content_hash=c_hash,
+                changed=changed,
+                error=None,
+            )
+
+        except requests.Timeout:
+            if attempt < MAX_RETRIES:
+                time.sleep(1)
+                continue
+            return URLStatus(
+                url=url,
+                status_code=0,
+                etag=None,
+                last_modified=None,
+                content_hash=None,
+                changed=False,
+                error="timeout",
+            )
+        except requests.ConnectionError:
+            return URLStatus(
+                url=url,
+                status_code=0,
+                etag=None,
+                last_modified=None,
+                content_hash=None,
+                changed=False,
+                error="connection_error",
+            )
+        except Exception as e:
+            return URLStatus(
+                url=url,
+                status_code=0,
+                etag=None,
+                last_modified=None,
+                content_hash=None,
+                changed=False,
+                error=str(e)[:80],
+            )
+
+    # Should not reach here, but be safe
+    return URLStatus(
+        url=url,
+        status_code=0,
+        etag=None,
+        last_modified=None,
+        content_hash=None,
+        changed=False,
+        error="max_retries",
+    )
+
+
+def _is_changed(
+    cached: dict,
+    etag: str | None,
+    last_modified: str | None,
+    content_hash: str | None,
+) -> bool:
+    """Compare current response headers against cached values.
+
+    Returns True if we detect a change, False if unchanged or no cached data
+    to compare against (first run is always 'unchanged' to avoid spurious rebuilds).
+    """
+    if not cached:
+        # First time checking this URL -- nothing to compare against
+        return False
+
+    # Content hash is the strongest signal
+    if content_hash and cached.get("content_hash"):
+        return content_hash != cached["content_hash"]
+
+    # ETag comparison
+    if etag and cached.get("etag"):
+        return etag != cached["etag"]
+
+    # Last-Modified comparison
+    if last_modified and cached.get("last_modified"):
+        return last_modified != cached["last_modified"]
+
+    # No comparable headers available -- assume unchanged
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Pack-level freshness check
+# ---------------------------------------------------------------------------
+
+
+def check_pack_freshness(
+    pack_dir: Path,
+    use_content_hash: bool = False,
+    workers: int = DEFAULT_WORKERS,
+    threshold: float = CHANGE_THRESHOLD,
+) -> PackFreshnessReport:
+    """Check all URLs in a pack and return a freshness report."""
+    pack_name = pack_dir.name
+    urls_file = pack_dir / "urls.txt"
+    urls = load_urls(urls_file)
+
+    if not urls:
+        return PackFreshnessReport(
+            pack_name=pack_name,
+            pack_dir=str(pack_dir),
+            total_urls=0,
+            checked=0,
+            changed_urls=[],
+            errored_urls=[],
+            change_ratio=0.0,
+            needs_rebuild=False,
+            checked_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        )
+
+    cache = load_cache(pack_dir)
+    results: list[URLStatus] = []
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(
+                check_url,
+                url,
+                cache.get(url, {}),
+                use_content_hash,
+            ): url
+            for url in urls
+        }
+        for future in concurrent.futures.as_completed(futures):
+            results.append(future.result())
+
+    # Update cache with fresh data
+    for r in results:
+        if r.error is None and r.status_code < 400:
+            entry: dict = {}
+            if r.etag:
+                entry["etag"] = r.etag
+            if r.last_modified:
+                entry["last_modified"] = r.last_modified
+            if r.content_hash:
+                entry["content_hash"] = r.content_hash
+            entry["checked_at"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+            cache[r.url] = entry
+
+    save_cache(pack_dir, cache)
+
+    changed = [r.url for r in results if r.changed]
+    errored = [r.url for r in results if r.error is not None]
+    checked_count = len(results) - len(errored)
+    change_ratio = len(changed) / max(checked_count, 1)
+
+    return PackFreshnessReport(
+        pack_name=pack_name,
+        pack_dir=str(pack_dir),
+        total_urls=len(urls),
+        checked=checked_count,
+        changed_urls=changed,
+        errored_urls=errored,
+        change_ratio=round(change_ratio, 4),
+        needs_rebuild=change_ratio >= threshold,
+        checked_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        details=results,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Multi-pack runner
+# ---------------------------------------------------------------------------
+
+
+def discover_packs(packs_root: Path) -> list[Path]:
+    """Find all pack directories that have a urls.txt."""
+    return sorted(d.parent for d in packs_root.glob("*/urls.txt"))
+
+
+def check_all_packs(
+    packs_root: Path,
+    use_content_hash: bool = False,
+    workers: int = DEFAULT_WORKERS,
+    threshold: float = CHANGE_THRESHOLD,
+) -> list[PackFreshnessReport]:
+    """Check freshness of all packs under packs_root."""
+    reports = []
+    for pack_dir in discover_packs(packs_root):
+        report = check_pack_freshness(pack_dir, use_content_hash, workers, threshold)
+        reports.append(report)
+    return reports
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check knowledge pack URL freshness",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("pack_dir", nargs="?", help="Path to a single pack directory")
+    parser.add_argument("--all", action="store_true", help="Check all packs under data/packs/")
+    parser.add_argument("--json", action="store_true", help="Output JSON report")
+    parser.add_argument("--content-hash", action="store_true", help="Use content hashing (slower)")
+    parser.add_argument("--workers", type=int, default=DEFAULT_WORKERS, help="Concurrent workers")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=CHANGE_THRESHOLD,
+        help=f"Change ratio to trigger rebuild (default: {CHANGE_THRESHOLD})",
+    )
+    args = parser.parse_args()
+
+    if not args.all and not args.pack_dir:
+        parser.print_help()
+        return 1
+
+    if args.all:
+        reports = check_all_packs(
+            Path("data/packs"),
+            use_content_hash=args.content_hash,
+            workers=args.workers,
+            threshold=args.threshold,
+        )
+    else:
+        pack_path = Path(args.pack_dir)
+        if not pack_path.is_dir():
+            print(f"Error: {pack_path} is not a directory", file=sys.stderr)
+            return 1
+        reports = [
+            check_pack_freshness(
+                pack_path,
+                use_content_hash=args.content_hash,
+                workers=args.workers,
+                threshold=args.threshold,
+            )
+        ]
+
+    if args.json:
+        output = []
+        for r in reports:
+            d = asdict(r)
+            # Remove verbose details from JSON summary by default
+            d.pop("details", None)
+            output.append(d)
+        print(json.dumps(output, indent=2))
+    else:
+        for r in reports:
+            status = "REBUILD" if r.needs_rebuild else "OK"
+            print(
+                f"[{status}] {r.pack_name}: "
+                f"{len(r.changed_urls)}/{r.checked} changed "
+                f"({r.change_ratio:.0%}), "
+                f"{len(r.errored_urls)} errors"
+            )
+            if r.changed_urls:
+                for url in r.changed_urls:
+                    print(f"  changed: {url}")
+
+    # Exit 0 if no rebuilds needed, 1 if any pack needs rebuild
+    needs_any = any(r.needs_rebuild for r in reports)
+    return 1 if needs_any else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add 10 new knowledge packs for AI/agentic coding domains, each with curated URLs, manifests, 50 eval questions, and build scripts
- All packs fully built with knowledge graphs (204 articles, 891 entities, 853 relationships total)
- Updated `generate_eval_questions.py` with domain descriptions for all 10 new packs

## Packs

| Pack | URLs | Eval Qs | Articles | Entities | Relations | DB Size |
|------|------|---------|----------|----------|-----------|---------|
| claude-agent-sdk | 34 | 50 | 24 | 121 | 114 | 28 MB |
| github-copilot-sdk | 31 | 50 | 19 | 95 | 78 | 27 MB |
| microsoft-agent-framework | 31 | 50 | 16 | 76 | 62 | 26 MB |
| workiq-mcp | 25 | 50 | 14 | 83 | 59 | 26 MB |
| langchain-expert | 36 | 50 | 16 | 43 | 53 | 26 MB |
| llamaindex-expert | 33 | 50 | 13 | 58 | 52 | 22 MB |
| semantic-kernel | 30 | 50 | 21 | 113 | 93 | 27 MB |
| autogen-expert | 31 | 50 | 23 | 98 | 97 | 27 MB |
| crew-ai-expert | 36 | 50 | 26 | 51 | 106 | 27 MB |
| model-context-protocol | 40 | 50 | 32 | 153 | 139 | 28 MB |
| **Totals** | **327** | **500** | **204** | **891** | **853** | **264 MB** |

## Files per pack

Each pack includes:
- `data/packs/{name}/urls.txt` - 25-40 authoritative documentation URLs
- `data/packs/{name}/manifest.json` - Pack metadata with graph stats
- `data/packs/{name}/eval/questions.json` - 50 evaluation Q&A pairs (easy/medium/hard)
- `data/packs/{name}/eval/questions.jsonl` - Same in JSONL format
- `scripts/build_{name}_pack.py` - Build script following existing pattern

## Test plan

- [x] All 10 build scripts execute successfully against their URL lists
- [x] All 10 packs produce pack.db with articles, entities, and relationships
- [x] All 50 eval questions per pack pass validation (correct fields, unique questions)
- [x] Pre-commit hooks pass (ruff, ruff-format, json check, large file check)
- [x] Build scripts follow exact same pattern as existing packs (e.g., build_mcp_protocol_pack.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)