### PR TITLE
Add CI workflow for building knowledge packs from GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/build-pack.yml
+++ b/.github/ISSUE_TEMPLATE/build-pack.yml
@@ -1,0 +1,71 @@
+name: Build Knowledge Pack
+description: Request a new knowledge pack be built and evaluated via CI
+title: "[Pack] "
+labels: ["build-pack"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Build a New Knowledge Pack
+
+        Fill out this form to trigger an automated CI build and evaluation of a new
+        knowledge pack. Only maintainers can trigger the workflow.
+
+  - type: input
+    id: pack_name
+    attributes:
+      label: Pack Name
+      description: >
+        Identifier for the pack (lowercase, hyphens only).
+        Example: aws-lambda-expert, react-hooks, bayesian-statistics
+      placeholder: my-topic-expert
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Domain Description
+      description: >
+        Describe the knowledge domain. This is used to generate evaluation
+        questions and guide URL discovery. Be specific about key subtopics.
+      placeholder: |
+        Expert knowledge of AWS Lambda covering function configuration,
+        event sources, layers, cold starts, concurrency, IAM permissions,
+        VPC integration, container images, and performance tuning.
+    validations:
+      required: true
+
+  - type: textarea
+    id: urls
+    attributes:
+      label: Seed URLs (one per line)
+      description: >
+        URLs to crawl for pack content. Leave empty to use search_terms for
+        automatic URL discovery.
+      placeholder: |
+        https://docs.aws.amazon.com/lambda/latest/dg/welcome.html
+        https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html
+      render: text
+
+  - type: input
+    id: search_terms
+    attributes:
+      label: Search Terms
+      description: >
+        Comma-separated search terms for automatic URL discovery. Used when
+        seed URLs are not provided or to supplement them.
+      placeholder: "AWS Lambda tutorial, Lambda best practices, Lambda cold start optimization"
+
+  - type: dropdown
+    id: article_count_target
+    attributes:
+      label: Article Count Target
+      description: How many articles to aim for in the pack.
+      options:
+        - "20"
+        - "50"
+        - "100"
+      default: 0
+    validations:
+      required: true

--- a/.github/workflows/build-pack.yml
+++ b/.github/workflows/build-pack.yml
@@ -1,0 +1,280 @@
+name: Build Knowledge Pack
+
+on:
+  issues:
+    types: [opened, labeled]
+
+concurrency:
+  group: build-pack-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.11"
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+jobs:
+  build-and-eval:
+    name: Build & Evaluate Pack
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Only run for maintainers/owners when 'build-pack' label is present
+    if: |
+      contains(github.event.issue.labels.*.name, 'build-pack') &&
+      (github.event.issue.author_association == 'OWNER' ||
+       github.event.issue.author_association == 'MEMBER' ||
+       github.event.issue.author_association == 'COLLABORATOR')
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - run: uv python install ${{ env.PYTHON_VERSION }}
+
+      - run: uv venv && uv pip install -e ".[dev]"
+
+      - name: Parse issue body and write JSON
+        id: parse
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = context.payload.issue.body || '';
+
+            function extractField(body, fieldId) {
+              // GitHub issue forms render as:  ### Label\n\nvalue\n\n### Next
+              const labelMap = {
+                'pack_name': 'Pack Name',
+                'description': 'Domain Description',
+                'urls': 'Seed URLs',
+                'search_terms': 'Search Terms',
+                'article_count_target': 'Article Count Target',
+              };
+              const patterns = [
+                new RegExp(`### .*${fieldId}.*\\n\\n([\\s\\S]*?)(?=\\n### |$)`, 'i'),
+              ];
+              if (labelMap[fieldId]) {
+                patterns.push(
+                  new RegExp(`### ${labelMap[fieldId]}\\n\\n([\\s\\S]*?)(?=\\n### |$)`, 'i')
+                );
+              }
+              for (const re of patterns) {
+                const m = body.match(re);
+                if (m && m[1].trim() && m[1].trim() !== '_No response_') {
+                  return m[1].trim();
+                }
+              }
+              return '';
+            }
+
+            const packName = extractField(body, 'pack_name');
+            const description = extractField(body, 'description');
+            const rawUrls = extractField(body, 'urls');
+            const searchTerms = extractField(body, 'search_terms');
+            const articleCountTarget = extractField(body, 'article_count_target') || '20';
+
+            // Parse URLs from multiline text
+            const urls = rawUrls
+              .split('\n')
+              .map(u => u.trim())
+              .filter(u => u.startsWith('http'));
+
+            // Write the complete issue payload to a file to avoid shell escaping issues
+            const issueData = {
+              pack_name: packName,
+              description: description,
+              urls: urls,
+              search_terms: searchTerms,
+              article_count_target: parseInt(articleCountTarget, 10) || 20,
+            };
+            fs.writeFileSync('issue_payload.json', JSON.stringify(issueData, null, 2));
+
+            core.setOutput('pack_name', packName);
+            core.setOutput('article_count_target', articleCountTarget);
+            console.log(`Parsed: pack_name=${packName}, target=${articleCountTarget}`);
+
+      - name: Validate pack name
+        id: validate
+        run: |
+          PACK_NAME=$(python3 -c "import json; print(json.load(open('issue_payload.json'))['pack_name'])")
+
+          if [ -z "$PACK_NAME" ]; then
+            echo "::error::Pack name is empty. Issue body may not match expected format."
+            exit 1
+          fi
+
+          # Allow only lowercase alphanumeric and hyphens, no leading/trailing hyphens
+          if ! echo "$PACK_NAME" | grep -qE '^[a-z0-9][a-z0-9-]*[a-z0-9]$'; then
+            if ! echo "$PACK_NAME" | grep -qE '^[a-z0-9]+$'; then
+              echo "::error::Invalid pack name '$PACK_NAME'. Use lowercase alphanumeric and hyphens only."
+              exit 1
+            fi
+          fi
+
+          if [ -f "data/packs/$PACK_NAME/pack.db" ] || [ -d "data/packs/$PACK_NAME/pack.db" ]; then
+            echo "::error::Pack '$PACK_NAME' already exists with a database."
+            exit 1
+          fi
+
+          echo "pack_name=$PACK_NAME" >> "$GITHUB_OUTPUT"
+          echo "Validated pack name: $PACK_NAME"
+
+      - name: Comment — build starting
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `**Pack build started** for \`${{ steps.validate.outputs.pack_name }}\`.\n\nWorkflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
+      - name: Build pack
+        id: build
+        run: |
+          # issue_payload.json was written by the parse step — no shell escaping needed
+          ISSUE_JSON=$(cat issue_payload.json)
+          echo "Issue JSON: $ISSUE_JSON"
+
+          uv run python scripts/build_pack_from_issue.py --issue-json "$ISSUE_JSON" \
+            | tee build_output.txt
+
+          RESULT_LINE=$(tail -1 build_output.txt)
+          echo "result_json=$RESULT_LINE" >> "$GITHUB_OUTPUT"
+
+      - name: Generate eval questions
+        run: |
+          PACK_NAME="${{ steps.validate.outputs.pack_name }}"
+          uv run python scripts/generate_eval_questions.py \
+            --pack "$PACK_NAME" \
+            --count 50
+
+      - name: Run evaluation (5-question sample)
+        id: eval
+        run: |
+          PACK_NAME="${{ steps.validate.outputs.pack_name }}"
+          RESULT=$(uv run python scripts/eval_single_pack.py "$PACK_NAME" --sample 5)
+          echo "$RESULT" | tee eval_result.json
+          echo "eval_json=$RESULT" >> "$GITHUB_OUTPUT"
+
+      - name: Create PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PACK_NAME="${{ steps.validate.outputs.pack_name }}"
+          BRANCH="auto/pack-${PACK_NAME}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+
+          # Add pack files (urls.txt, manifest, eval questions, build script)
+          # Do NOT add .db files — they are too large for git
+          git add "data/packs/${PACK_NAME}/urls.txt" || true
+          git add "data/packs/${PACK_NAME}/manifest.json" || true
+          git add "data/packs/${PACK_NAME}/eval/" || true
+          git add "scripts/build_${PACK_NAME//-/_}_pack.py" || true
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 1
+          fi
+
+          git commit -m "feat: add ${PACK_NAME} knowledge pack
+
+          Built from issue #${{ github.event.issue.number }}.
+          Contains urls.txt, manifest.json, eval questions, and build script."
+
+          git push origin "$BRANCH"
+
+          # Build PR body with eval results
+          EVAL_RESULT=$(cat eval_result.json 2>/dev/null || echo '{}')
+          PACK_AVG=$(echo "$EVAL_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('pack',{}).get('avg','N/A'))" 2>/dev/null || echo "N/A")
+          TRAIN_AVG=$(echo "$EVAL_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('training',{}).get('avg','N/A'))" 2>/dev/null || echo "N/A")
+          DELTA=$(echo "$EVAL_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('delta','N/A'))" 2>/dev/null || echo "N/A")
+          N_QUESTIONS=$(echo "$EVAL_RESULT" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('n','N/A'))" 2>/dev/null || echo "N/A")
+
+          PACK_VAR="${PACK_NAME//-/_}"
+          cat > pr_body.md <<EOF
+          ## New Knowledge Pack: ${PACK_NAME}
+
+          Built automatically from issue #${{ github.event.issue.number }}.
+
+          ### Eval Results (${N_QUESTIONS} questions sampled)
+
+          | Metric | Training (baseline) | Pack (KG Agent) | Delta |
+          |--------|-------------------|-----------------|-------|
+          | Avg Score (0-10) | ${TRAIN_AVG} | ${PACK_AVG} | ${DELTA} |
+
+          ### Contents
+
+          - \`data/packs/${PACK_NAME}/urls.txt\` -- source URLs
+          - \`data/packs/${PACK_NAME}/manifest.json\` -- pack metadata
+          - \`data/packs/${PACK_NAME}/eval/\` -- evaluation questions
+          - \`scripts/build_${PACK_VAR}_pack.py\` -- reproducible build script
+
+          > The pack database (pack.db) is not included in the PR due to size.
+          > Run: uv run python scripts/build_${PACK_VAR}_pack.py to rebuild locally.
+
+          Closes #${{ github.event.issue.number }}
+          EOF
+          # Strip leading whitespace from heredoc lines (indented for YAML readability)
+          sed -i 's/^          //' pr_body.md
+
+          PR_URL=$(gh pr create \
+            --title "feat: add ${PACK_NAME} knowledge pack" \
+            --body-file pr_body.md \
+            --label "build-pack")
+
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on issue with results
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const prUrl = '${{ steps.pr.outputs.pr_url }}' || 'N/A';
+
+            let evalSummary = 'Eval did not complete.';
+            try {
+              const raw = fs.readFileSync('eval_result.json', 'utf8').trim();
+              const ev = JSON.parse(raw);
+              evalSummary = [
+                `**Eval Results** (${ev.n} questions):`,
+                '',
+                '| Metric | Training | Pack | Delta |',
+                '|--------|----------|------|-------|',
+                `| Avg Score | ${ev.training?.avg ?? "N/A"} | ${ev.pack?.avg ?? "N/A"} | ${ev.delta ?? "N/A"} |`,
+                `| Accuracy (>=7) | ${ev.training?.acc ?? "N/A"}% | ${ev.pack?.acc ?? "N/A"}% | — |`,
+              ].join('\n');
+            } catch (e) {
+              console.log('Could not parse eval result:', e.message);
+            }
+
+            const status = '${{ job.status }}';
+            const icon = status === 'success' ? ':white_check_mark:' : ':x:';
+
+            const body = [
+              `${icon} **Pack build ${status}** for \`${{ steps.validate.outputs.pack_name }}\``,
+              '',
+              evalSummary,
+              '',
+              prUrl !== 'N/A' ? `**PR**: ${prUrl}` : '',
+              '',
+              `[Workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+            ].filter(Boolean).join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/docs/ci-pack-building.md
+++ b/docs/ci-pack-building.md
@@ -1,0 +1,139 @@
+# CI Pack Building
+
+Automated pipeline for building and evaluating knowledge packs from GitHub
+issues.
+
+## How It Works
+
+```
+1. Maintainer creates issue    2. CI parses & validates    3. Build pack DB
+   (using template)               (pack name, URLs)           (test-mode: 5 URLs)
+
+4. Generate eval questions     5. Run eval (5-question)    6. Create PR
+   (50 questions via Claude)      (training vs pack)          (urls.txt, manifest, eval, script)
+
+7. Comment on issue with eval results and PR link
+```
+
+## Quick Start
+
+1. Go to **Issues > New Issue** and pick the **Build Knowledge Pack** template.
+2. Fill in the fields:
+   - **Pack Name**: lowercase with hyphens, e.g. `aws-lambda-expert`
+   - **Domain Description**: detailed description of the knowledge domain
+   - **Seed URLs**: (optional) one URL per line
+   - **Search Terms**: (optional) comma-separated terms for URL discovery
+   - **Article Count Target**: 20, 50, or 100
+3. Submit the issue. The `build-pack` label is applied automatically by the
+   template.
+4. CI runs and posts results as a comment on the issue.
+5. A PR is created with all pack files (except the database, which is too large
+   for git).
+
+## Security
+
+The workflow only runs when the issue author has `OWNER`, `MEMBER`, or
+`COLLABORATOR` association with the repository. This prevents arbitrary users
+from triggering builds that consume API credits.
+
+Pack names are validated against `^[a-z0-9][a-z0-9-]*[a-z0-9]$` before being
+used in any file path operations.
+
+The workflow has a 30-minute timeout to prevent runaway builds.
+
+## Required Secrets
+
+| Secret | Required | Purpose |
+|--------|----------|---------|
+| `ANTHROPIC_API_KEY` | Yes | LLM extraction and eval scoring |
+| `HF_TOKEN` | No | Faster Hugging Face model downloads |
+
+## What Gets Created
+
+For a pack named `my-topic`:
+
+```
+data/packs/my-topic/
+  urls.txt              # Source URLs
+  manifest.json         # Pack metadata and graph stats
+  pack.db/              # Kuzu database (NOT in git)
+  eval/
+    questions.json      # 50 eval questions (JSON array)
+    questions.jsonl     # Same questions (JSONL format)
+
+scripts/build_my_topic_pack.py   # Reproducible build script
+```
+
+The PR includes everything except `pack.db` (too large for git). To rebuild the
+database locally:
+
+```bash
+uv run python scripts/build_my_topic_pack.py
+```
+
+Or in test mode (5 URLs only):
+
+```bash
+uv run python scripts/build_my_topic_pack.py --test-mode
+```
+
+## URL Discovery
+
+If you provide **Seed URLs**, those are used directly.
+
+If you provide **Search Terms** without URLs, the pipeline asks Claude to suggest
+authoritative documentation URLs for the topic. This works well for established
+technologies with official documentation sites.
+
+For best results, provide seed URLs for niche topics and use search terms for
+well-documented technologies.
+
+## Eval Results
+
+The eval compares two approaches on 5 sampled questions:
+
+- **Training (baseline)**: Claude answers from training data alone
+- **Pack (KG Agent)**: Claude answers using the knowledge graph
+
+Scores are 0-10 per question, judged by Claude Haiku. The `delta` shows how much
+the pack improves over baseline training knowledge.
+
+A positive delta means the pack adds value beyond what Claude already knows.
+
+## Manual Build
+
+You can run the orchestrator script directly without CI:
+
+```bash
+uv run python scripts/build_pack_from_issue.py --issue-json '{
+  "pack_name": "my-topic",
+  "description": "Expert knowledge of ...",
+  "urls": ["https://docs.example.com/guide"],
+  "search_terms": "",
+  "article_count_target": 20
+}'
+```
+
+## Troubleshooting
+
+### Build fails with "No URLs provided"
+
+Either provide seed URLs in the issue or provide search terms so the pipeline can
+discover URLs automatically.
+
+### Build times out
+
+The workflow has a 30-minute timeout. If your pack has many URLs, reduce the
+article count target or provide fewer seed URLs. The build runs in test-mode
+(5 URLs) in CI — full builds should be done locally.
+
+### Pack already exists
+
+If `data/packs/{name}/pack.db` already exists, the validation step rejects the
+build. Delete the existing pack first or use a different name.
+
+### Eval scores are low
+
+Low scores (< 5.0) usually mean the source URLs don't contain enough relevant
+content. Try adding more specific documentation URLs or adjusting the domain
+description.

--- a/scripts/build_pack_from_issue.py
+++ b/scripts/build_pack_from_issue.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Build a knowledge pack from a GitHub issue JSON payload.
+
+Orchestrates the full pack-build pipeline: scaffold, URL discovery,
+build script generation, database build, and eval question generation.
+
+Usage:
+    python scripts/build_pack_from_issue.py --issue-json '{"pack_name":"aws-lambda","description":"..."}'
+
+Input JSON fields:
+    pack_name (str, required): Pack identifier (lowercase, hyphens)
+    description (str, required): Domain description for eval question generation
+    urls (list[str], optional): Seed URLs to crawl
+    search_terms (str, optional): Comma-separated terms for URL discovery
+    article_count_target (int, optional): Target article count (default 20)
+
+Output:
+    Prints JSON result on the last line with build statistics.
+"""
+
+import argparse
+import json
+import logging
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).parent.parent
+
+
+def validate_pack_name(name: str) -> str:
+    """Validate pack name: lowercase alphanumeric and hyphens only."""
+    if not name:
+        raise ValueError("Pack name is required")
+    if not re.match(r"^[a-z0-9][a-z0-9-]*[a-z0-9]$", name) and not re.match(r"^[a-z0-9]+$", name):
+        raise ValueError(
+            f"Invalid pack name '{name}': use lowercase alphanumeric and hyphens only, "
+            "no leading/trailing hyphens"
+        )
+    if len(name) > 60:
+        raise ValueError(f"Pack name too long ({len(name)} chars, max 60)")
+    return name
+
+
+def discover_urls_from_search(search_terms: str, target_count: int) -> list[str]:
+    """Use the Anthropic API to suggest documentation URLs from search terms.
+
+    This is a lightweight approach: ask Claude to suggest authoritative URLs
+    for the given topic rather than running a web search.
+    """
+    try:
+        from anthropic import Anthropic
+
+        client = Anthropic()
+        prompt = (
+            f"List {target_count} authoritative documentation URLs for learning about: {search_terms}\n\n"
+            "Requirements:\n"
+            "- Only include real, currently-accessible URLs\n"
+            "- Prefer official documentation sites\n"
+            "- Include a mix of getting-started, reference, and advanced topics\n"
+            "- One URL per line, no numbering or descriptions\n"
+            "- Only output URLs, nothing else"
+        )
+        response = client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=2048,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        text = response.content[0].text
+        urls = [line.strip() for line in text.splitlines() if line.strip().startswith("http")]
+        logger.info(f"Discovered {len(urls)} URLs from search terms")
+        return urls
+    except Exception as e:
+        logger.warning(f"URL discovery failed: {e}")
+        return []
+
+
+def create_urls_file(pack_dir: Path, urls: list[str], pack_name: str) -> Path:
+    """Write urls.txt for the pack."""
+    urls_path = pack_dir / "urls.txt"
+    with open(urls_path, "w") as f:
+        f.write(f"# {pack_name} - Source URLs\n")
+        f.write(f"# Generated {datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')}\n\n")
+        for url in urls:
+            f.write(f"{url}\n")
+    logger.info(f"Created {urls_path} with {len(urls)} URLs")
+    return urls_path
+
+
+def generate_build_script(pack_name: str, description: str) -> Path:
+    """Generate a build script from the standard template."""
+    # Derive identifiers from pack name
+    pack_var = pack_name.replace("-", "_")
+    # Category: title-case the pack name without trailing -expert
+    category_base = pack_name.replace("-expert", "").replace("-", " ")
+    category = category_base.title()
+    domain = pack_var.replace("_expert", "")
+
+    script_path = PROJECT_ROOT / "scripts" / f"build_{pack_var}_pack.py"
+
+    content = f'''#!/usr/bin/env python3
+"""
+Build {category} Knowledge Pack from URLs.
+
+Reads documentation URLs from urls.txt and builds a complete
+knowledge graph with LLM-based extraction using the web content pipeline.
+
+Usage:
+    python scripts/build_{pack_var}_pack.py [--test-mode]
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+os.environ["LOKY_MAX_CPU_COUNT"] = "1"
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import kuzu  # noqa: E402
+
+from bootstrap.schema.ryugraph_schema import create_schema  # noqa: E402
+from bootstrap.src.embeddings.generator import EmbeddingGenerator  # noqa: E402
+from bootstrap.src.extraction.llm_extractor import get_extractor  # noqa: E402
+from bootstrap.src.sources.web import WebContentSource  # noqa: E402
+
+PACK_NAME = "{pack_name}"
+PACK_DIR = Path(f"data/packs/{{PACK_NAME}}")
+URLS_FILE = PACK_DIR / "urls.txt"
+DB_PATH = PACK_DIR / "pack.db"
+MANIFEST_PATH = PACK_DIR / "manifest.json"
+CATEGORY = "{category}"
+DOMAIN = "{domain}"
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers=[
+        logging.StreamHandler(),
+        logging.FileHandler(f"logs/build_{{PACK_NAME.replace('-', '_')}}_pack.log"),
+    ],
+)
+logger = logging.getLogger(__name__)
+
+
+def load_urls(urls_file: Path, limit: int | None = None) -> list[str]:
+    with open(urls_file) as f:
+        urls = [
+            line.strip()
+            for line in f
+            if line.strip() and not line.strip().startswith("#") and line.strip().startswith("http")
+        ]
+    if limit:
+        urls = urls[:limit]
+        logger.info(f"Limited to {{limit}} URLs for testing")
+    logger.info(f"Loaded {{len(urls)}} URLs from {{urls_file}}")
+    return urls
+
+
+def process_url(url, conn, web_source, embedder, extractor) -> bool:
+    try:
+        article = web_source.fetch_article(url)
+        if not article or not article.content:
+            logger.warning(f"No content for {{url}}")
+            return False
+        title = article.title
+        result = conn.execute(
+            "MATCH (a:Article {{title: $title}}) RETURN a.title AS title", {{"title": title}}
+        )
+        if not result.get_as_df().empty:
+            logger.info(f"Skipping {{title!r}} (already exists)")
+            return True
+        sections = web_source.parse_sections(article.content)
+        if not sections:
+            sections = [{{"title": "Overview", "content": article.content, "level": 1}}]
+        extraction = extractor.extract_from_article(
+            title=title, sections=sections, max_sections=5, domain=DOMAIN
+        )
+        word_count = sum(len(s["content"].split()) for s in sections)
+        conn.execute(
+            "CREATE (a:Article {{title: $title, category: $category, word_count: $wc}})",
+            {{"title": title, "category": CATEGORY, "wc": word_count}},
+        )
+        for entity in extraction.entities:
+            conn.execute(
+                "MERGE (e:Entity {{entity_id: $eid}}) ON CREATE SET e.name = $name, e.type = $type",
+                {{"eid": entity.name, "name": entity.name, "type": entity.type}},
+            )
+            conn.execute(
+                "MATCH (a:Article {{title: $title}}), (e:Entity {{entity_id: $eid}}) "
+                "MERGE (a)-[:HAS_ENTITY]->(e)",
+                {{"title": title, "eid": entity.name}},
+            )
+        for rel in extraction.relationships:
+            for eid in (rel.source, rel.target):
+                conn.execute(
+                    "MERGE (e:Entity {{entity_id: $eid}}) ON CREATE SET e.name = $eid, e.type = 'concept'",
+                    {{"eid": eid}},
+                )
+            conn.execute(
+                "MATCH (s:Entity {{entity_id: $source}}), (t:Entity {{entity_id: $target}}) "
+                "MERGE (s)-[:ENTITY_RELATION {{relation: $rel, context: $ctx}}]->(t)",
+                {{
+                    "source": rel.source,
+                    "target": rel.target,
+                    "rel": rel.relation,
+                    "ctx": rel.context,
+                }},
+            )
+        for idx, fact in enumerate(extraction.key_facts):
+            conn.execute(
+                "MATCH (a:Article {{title: $title}}) "
+                "CREATE (a)-[:HAS_FACT]->(f:Fact {{fact_id: $fid, content: $content}})",
+                {{"title": title, "fid": f"{{title}}:fact:{{idx}}", "content": fact}},
+            )
+        for idx, section in enumerate(sections[:3]):
+            sid = f"{{title}}#{{idx}}"
+            content = section["content"]
+            embedding = embedder.generate([content])[0].tolist()
+            conn.execute(
+                "MATCH (a:Article {{title: $title}}) "
+                "CREATE (a)-[:HAS_SECTION {{section_index: $idx}}]->"
+                "(s:Section {{section_id: $sid, content: $content, embedding: $emb}})",
+                {{"title": title, "idx": idx, "sid": sid, "content": content, "emb": embedding}},
+            )
+        logger.info(f"Processed {{url!r}} -> {{title!r}}")
+        return True
+    except Exception as e:
+        logger.error(f"Failed to process {{url}}: {{e}}")
+        return False
+
+
+def create_manifest(db_path, manifest_path, articles, entities, relationships):
+    size_mb = db_path.stat().st_size / (1024 * 1024) if db_path.exists() else 0
+    manifest = {{
+        "name": PACK_NAME,
+        "version": "1.0.0",
+        "description": """{description}""",
+        "graph_stats": {{
+            "articles": int(articles),
+            "entities": int(entities),
+            "relationships": int(relationships),
+            "size_mb": round(size_mb, 2),
+        }},
+        "eval_scores": {{"accuracy": 0.0, "hallucination_rate": 0.0, "citation_quality": 0.0}},
+        "source_urls": [],
+        "created": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "license": "MIT",
+    }}
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2)
+        f.write("\\n")
+    logger.info(f"Manifest saved to {{manifest_path}}")
+
+
+def build_pack(test_mode=False):
+    limit = 5 if test_mode else None
+    urls = load_urls(URLS_FILE, limit=limit)
+    if test_mode:
+        logger.info("TEST MODE: Building 5-URL pack")
+    if DB_PATH.exists():
+        if test_mode:
+            import shutil
+
+            shutil.rmtree(DB_PATH) if DB_PATH.is_dir() else DB_PATH.unlink()
+        else:
+            logger.warning(f"Database already exists: {{DB_PATH}}")
+            response = input("Delete and rebuild? (y/N): ")
+            if response.lower() != "y":
+                return
+            import shutil
+
+            shutil.rmtree(DB_PATH) if DB_PATH.is_dir() else DB_PATH.unlink()
+    create_schema(str(DB_PATH), drop_existing=True)
+    db = kuzu.Database(str(DB_PATH))
+    conn = kuzu.Connection(db)
+    web_source = WebContentSource()
+    embedder = EmbeddingGenerator()
+    extractor = get_extractor()
+    successful, failed = 0, 0
+    for i, url in enumerate(urls, 1):
+        logger.info(f"Processing {{i}}/{{len(urls)}}: {{url}}")
+        if process_url(url, conn, web_source, embedder, extractor):
+            successful += 1
+        else:
+            failed += 1
+    a = conn.execute("MATCH (a:Article) RETURN count(a) AS c").get_as_df().iloc[0]["c"]
+    e = conn.execute("MATCH (e:Entity) RETURN count(e) AS c").get_as_df().iloc[0]["c"]
+    r = (
+        conn.execute("MATCH ()-[r:ENTITY_RELATION]->() RETURN count(r) AS c")
+        .get_as_df()
+        .iloc[0]["c"]
+    )
+    logger.info(f"Build complete: {{successful}} successful, {{failed}} failed")
+    logger.info(f"Final stats: {{a}} articles, {{e}} entities, {{r}} relationships")
+    create_manifest(DB_PATH, MANIFEST_PATH, a, e, r)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=f"Build {{PACK_NAME}} Knowledge Pack")
+    parser.add_argument("--test-mode", action="store_true", help="Build 5-URL pack for testing")
+    args = parser.parse_args()
+    Path("logs").mkdir(exist_ok=True)
+    try:
+        build_pack(test_mode=args.test_mode)
+    except KeyboardInterrupt:
+        logger.info("Build interrupted")
+        sys.exit(1)
+    except Exception as e:
+        logger.error(f"Build failed: {{e}}", exc_info=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+    with open(script_path, "w") as f:
+        f.write(content)
+    script_path.chmod(0o755)
+    logger.info(f"Generated build script: {script_path}")
+    return script_path
+
+
+def run_build_script(pack_name: str) -> dict:
+    """Run the generated build script in test-mode."""
+    pack_var = pack_name.replace("-", "_")
+    script = PROJECT_ROOT / "scripts" / f"build_{pack_var}_pack.py"
+
+    if not script.exists():
+        raise FileNotFoundError(f"Build script not found: {script}")
+
+    # Ensure logs directory exists
+    (PROJECT_ROOT / "logs").mkdir(exist_ok=True)
+
+    logger.info(f"Running build script: {script} --test-mode")
+    result = subprocess.run(
+        ["uv", "run", "python", str(script), "--test-mode"],
+        cwd=str(PROJECT_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=1200,  # 20 minutes max
+    )
+
+    if result.returncode != 0:
+        logger.error(f"Build script failed:\nstdout: {result.stdout}\nstderr: {result.stderr}")
+        return {"success": False, "error": result.stderr[-500:] if result.stderr else "unknown"}
+
+    logger.info("Build script completed successfully")
+    return {"success": True}
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Build a knowledge pack from a GitHub issue JSON payload"
+    )
+    parser.add_argument(
+        "--issue-json",
+        required=True,
+        help="JSON string with pack_name, description, urls, search_terms, article_count_target",
+    )
+    args = parser.parse_args()
+
+    try:
+        issue = json.loads(args.issue_json)
+    except json.JSONDecodeError as e:
+        print(json.dumps({"error": f"Invalid JSON: {e}"}))
+        sys.exit(1)
+
+    pack_name = issue.get("pack_name", "").strip()
+    description = issue.get("description", "").strip()
+    urls = issue.get("urls", [])
+    search_terms = issue.get("search_terms", "").strip()
+    article_count_target = int(issue.get("article_count_target", 20))
+
+    # Validate
+    try:
+        pack_name = validate_pack_name(pack_name)
+    except ValueError as e:
+        print(json.dumps({"error": str(e)}))
+        sys.exit(1)
+
+    if not description:
+        print(json.dumps({"error": "Description is required"}))
+        sys.exit(1)
+
+    # Create pack directory
+    pack_dir = PROJECT_ROOT / "data" / "packs" / pack_name
+    pack_dir.mkdir(parents=True, exist_ok=True)
+    (pack_dir / "eval").mkdir(exist_ok=True)
+
+    # Resolve URLs
+    if isinstance(urls, str):
+        urls = [u.strip() for u in urls.splitlines() if u.strip().startswith("http")]
+
+    if not urls and search_terms:
+        logger.info(f"No seed URLs provided. Discovering from search terms: {search_terms}")
+        urls = discover_urls_from_search(search_terms, target_count=article_count_target)
+
+    if not urls:
+        print(json.dumps({"error": "No URLs provided and URL discovery returned no results"}))
+        sys.exit(1)
+
+    # Limit URLs to target count
+    urls = urls[:article_count_target]
+    logger.info(f"Using {len(urls)} URLs (target: {article_count_target})")
+
+    # Step 1: Create urls.txt
+    create_urls_file(pack_dir, urls, pack_name)
+
+    # Step 2: Generate build script
+    script_path = generate_build_script(pack_name, description)
+
+    # Step 3: Run build script (test-mode: processes first 5 URLs)
+    build_result = run_build_script(pack_name)
+
+    # Step 4: Read manifest for stats
+    manifest_path = pack_dir / "manifest.json"
+    manifest = {}
+    if manifest_path.exists():
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+
+    result = {
+        "pack_name": pack_name,
+        "urls_count": len(urls),
+        "article_count_target": article_count_target,
+        "build_success": build_result.get("success", False),
+        "build_error": build_result.get("error"),
+        "graph_stats": manifest.get("graph_stats", {}),
+        "script_path": str(script_path),
+        "pack_dir": str(pack_dir),
+    }
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds a GitHub issue form template (`.github/ISSUE_TEMPLATE/build-pack.yml`) that lets maintainers request new knowledge packs by filling in pack name, domain description, seed URLs, search terms, and article count target
- Adds a GitHub Actions workflow (`.github/workflows/build-pack.yml`) triggered by issues with the `build-pack` label that orchestrates the full build pipeline: parse issue, validate, scaffold, build DB (test-mode), generate 50 eval questions, run 5-question eval, create PR, and comment results on the issue
- Adds orchestrator script (`scripts/build_pack_from_issue.py`) that handles URL discovery, build script generation from template, and database build coordination
- Adds documentation (`docs/ci-pack-building.md`) covering the full pipeline, required secrets, troubleshooting, and manual usage

### Security

- Workflow only triggers for `OWNER`, `MEMBER`, or `COLLABORATOR` author associations
- Pack names validated with strict regex before any path operations
- 30-minute job timeout prevents runaway builds
- Issue payload written to JSON file (avoids shell injection via issue body text)

### Required Secrets

| Secret | Required | Purpose |
|--------|----------|---------|
| `ANTHROPIC_API_KEY` | Yes | LLM extraction and eval scoring |
| `HF_TOKEN` | No | Faster HuggingFace model downloads |

## Test plan

- [ ] Create a test issue using the `Build Knowledge Pack` template with a known pack name and seed URLs
- [ ] Verify the workflow triggers and the `build-pack` label is present
- [ ] Verify pack name validation rejects invalid names (uppercase, spaces, leading hyphens)
- [ ] Verify the orchestrator script generates valid build scripts that compile and pass ruff
- [ ] Verify eval results are posted as a comment on the issue
- [ ] Verify a PR is created with urls.txt, manifest.json, eval questions, and build script (no .db)
- [ ] Verify the workflow does NOT trigger for non-maintainer issue authors

Generated with [Claude Code](https://claude.com/claude-code)