### PR TITLE
fix: round 3 review findings — sanitize_error, config drift, testpaths, thread safety

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,3 +1,3 @@
 """WikiGR Visualization Backend."""
 
-__version__ = "1.0.0"
+__version__ = "0.4.1"

--- a/backend/db/connection.py
+++ b/backend/db/connection.py
@@ -81,9 +81,10 @@ class ConnectionManager:
 
     def close(self):
         """Close database (release Database instance)."""
-        if self._database is not None:
-            self._database = None
-            logger.info("Closed LadybugDB database")
+        with self._lock:
+            if self._database is not None:
+                self._database = None
+                logger.info("Closed LadybugDB database")
 
 
 def _load_extensions(conn: kuzu.Connection) -> None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -39,6 +39,10 @@ async def lifespan(_app: FastAPI):
     logger.info(f"CORS origins: {settings.cors_origins}")
     yield
     logger.info("Shutting down WikiGR Visualization API")
+    # Shut down the chat streaming thread pool to avoid leaked threads
+    from backend.api.v1.chat import _stream_executor
+
+    _stream_executor.shutdown(wait=False)
 
 
 # Create FastAPI app

--- a/bootstrap/src/__init__.py
+++ b/bootstrap/src/__init__.py
@@ -1,3 +1,3 @@
 """WikiGR - Wikipedia Knowledge Graph System"""
 
-__version__ = "0.1.0"
+__version__ = "0.4.1"

--- a/bootstrap/src/config.py
+++ b/bootstrap/src/config.py
@@ -34,7 +34,7 @@ class Config:
                     "timeout": 30,
                 },
                 "embeddings": {
-                    "model_name": "paraphrase-MiniLM-L3-v2",
+                    "model_name": "BAAI/bge-base-en-v1.5",
                     "batch_size": 32,
                     "use_gpu": None,
                 },

--- a/bootstrap/src/database/loader.py
+++ b/bootstrap/src/database/loader.py
@@ -120,7 +120,9 @@ class ArticleLoader:
             return (True, None)
 
         except Exception as e:
-            error_msg = f"Failed to load article {title}: {str(e)}"
+            from wikigr.utils import sanitize_error
+
+            error_msg = f"Failed to load article {title}: {sanitize_error(str(e))}"
             logger.error(error_msg, exc_info=True)
             return (False, error_msg)
 

--- a/bootstrap/src/query/search.py
+++ b/bootstrap/src/query/search.py
@@ -181,7 +181,7 @@ def graph_traversal(
             ...
         ]
     """
-    max_hops = max(1, min(int(max_hops), 3))  # Validate: integer 1-3
+    max_hops = max(1, min(int(max_hops), 10))  # Validate: integer 1-10 (API endpoints cap at 3)
 
     logger.info(f"Graph traversal from: {seed_title} (max_hops={max_hops})")
 

--- a/config.yaml
+++ b/config.yaml
@@ -13,7 +13,7 @@ wikipedia:
 
 # Embeddings
 embeddings:
-  model_name: "paraphrase-MiniLM-L3-v2"
+  model_name: "BAAI/bge-base-en-v1.5"
   batch_size: 32
   use_gpu: true  # auto-detect if null
 

--- a/data/packs/ladybugdb-expert/manifest.json
+++ b/data/packs/ladybugdb-expert/manifest.json
@@ -4,8 +4,8 @@
   "description": "Comprehensive knowledge of LadybugDB, the active community fork of the archived Kuzu graph database. Covers the Python SDK (real_ladybug package), Cypher query language, vector search extensions, full-text search, graph algorithms, import/export, and migration from Kuzu.",
   "graph_stats": {
     "articles": 5,
-    "entities": 32,
-    "relationships": 21,
+    "entities": 27,
+    "relationships": 20,
     "size_mb": 2.08
   },
   "eval_scores": {
@@ -27,6 +27,6 @@
     "https://docs.ladybugdb.com/extensions/vector/",
     "https://github.com/LadybugDB/ladybug"
   ],
-  "created": "2026-03-06T18:13:54.524486Z",
+  "created": "2026-03-06T18:43:23.135465Z",
   "license": "MIT"
 }

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -70,14 +70,13 @@ Or use the context manager form:
 ```python
 from wikigr.agent.kg_agent import KnowledgeGraphAgent
 
-agent = KnowledgeGraphAgent(
+with KnowledgeGraphAgent(
     db_path="data/packs/go-expert/pack.db",
     use_enhancements=True,
-)
-
-result = agent.query("What is goroutine scheduling?")
-print(result["answer"])
-print(f"Sources: {result['sources']}")
+) as agent:
+    result = agent.query("What is goroutine scheduling?")
+    print(result["answer"])
+    print(f"Sources: {result['sources']}")
 ```
 
 The agent will:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ pythonPlatform = "Linux"
 
 [tool.pytest.ini_options]
 minversion = "8.0"
-testpaths = ["bootstrap/src/embeddings/tests", "bootstrap/src/expansion/tests", "bootstrap/src/wikipedia/tests", "bootstrap/src/database/tests", "bootstrap/src/query/tests", "bootstrap/tests", "tests/agent", "tests/packs", "tests/scripts"]
+testpaths = ["bootstrap/src/embeddings/tests", "bootstrap/src/expansion/tests", "bootstrap/src/wikipedia/tests", "bootstrap/src/database/tests", "bootstrap/src/query/tests", "bootstrap/src/extraction/tests", "bootstrap/src/sources/tests", "tests/agent", "tests/packs", "tests/scripts", "tests/cli", "tests/docs", "tests/outside_in", "tests/backend"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # WikiGR - Wikipedia Knowledge Graph
-# Python 3.10+
+# Python 3.12+
 
 # Core dependencies
 real_ladybug>=0.15.0,<0.16.0

--- a/scripts/build_pack_from_issue.py
+++ b/scripts/build_pack_from_issue.py
@@ -370,7 +370,9 @@ def main():
     try:
         pack_name = validate_pack_name(pack_name)
     except ValueError as e:
-        print(json.dumps({"error": str(e)}))
+        from wikigr.utils import sanitize_error
+
+        print(json.dumps({"error": sanitize_error(str(e))}))
         sys.exit(1)
 
     if not description:

--- a/scripts/check_pack_freshness.py
+++ b/scripts/check_pack_freshness.py
@@ -248,6 +248,8 @@ def check_url(
                 error="connection_error",
             )
         except Exception as e:
+            from wikigr.utils import sanitize_error
+
             return URLStatus(
                 url=url,
                 status_code=0,
@@ -255,7 +257,7 @@ def check_url(
                 last_modified=None,
                 content_hash=None,
                 changed=False,
-                error=str(e)[:80],
+                error=sanitize_error(str(e))[:80],
             )
 
 

--- a/scripts/rebuild_all_packs.py
+++ b/scripts/rebuild_all_packs.py
@@ -102,8 +102,15 @@ def rebuild_pack(script_path: Path, test_mode: bool = False) -> dict:
         return {"pack": pack_name, "status": "timeout", "elapsed": elapsed}
     except Exception as e:
         elapsed = time.time() - start
-        logger.error(f"[{pack_name}] Build error: {e}")
-        return {"pack": pack_name, "status": "error", "elapsed": elapsed, "error": str(e)}
+        from wikigr.utils import sanitize_error
+
+        logger.error(f"[{pack_name}] Build error: {sanitize_error(str(e))}")
+        return {
+            "pack": pack_name,
+            "status": "error",
+            "elapsed": elapsed,
+            "error": sanitize_error(str(e)),
+        }
 
 
 def main():

--- a/scripts/validate_pack_urls.py
+++ b/scripts/validate_pack_urls.py
@@ -49,7 +49,9 @@ def check_url(url: str, timeout: int = 10, retries: int = 2) -> tuple[str, int, 
                 continue
             return (url, 0, "timeout")
         except Exception as e:
-            return (url, 0, str(e)[:60])
+            from wikigr.utils import sanitize_error
+
+            return (url, 0, sanitize_error(str(e))[:60])
 
 
 def validate_file(urls_path: Path, fix: bool = False, workers: int = 10) -> dict:

--- a/wikigr/__init__.py
+++ b/wikigr/__init__.py
@@ -1,5 +1,5 @@
 """WikiGR - Wikipedia Knowledge Graph system with semantic search and AI capabilities."""
 
-__version__ = "0.1.0"
+__version__ = "0.4.1"
 
 __all__ = ["agent", "packs"]

--- a/wikigr/packs/edge_generator.py
+++ b/wikigr/packs/edge_generator.py
@@ -59,12 +59,12 @@ def generate_cooccurrence_edges(conn) -> int:
                 # Create bidirectional edges
                 conn.execute(
                     "MATCH (a:Article {title: $src}), (b:Article {title: $dst}) "
-                    "CREATE (a)-[:LINKS_TO]->(b)",
+                    "MERGE (a)-[:LINKS_TO]->(b)",
                     {"src": src, "dst": dst},
                 )
                 conn.execute(
                     "MATCH (a:Article {title: $src}), (b:Article {title: $dst}) "
-                    "CREATE (b)-[:LINKS_TO]->(a)",
+                    "MERGE (b)-[:LINKS_TO]->(a)",
                     {"src": src, "dst": dst},
                 )
                 edges_created += 2

--- a/wikigr/utils.py
+++ b/wikigr/utils.py
@@ -1,0 +1,72 @@
+"""Shared utility functions for WikiGR."""
+
+import re
+
+# Pre-compiled patterns for sanitize_error (avoids re-compiling on every call)
+_RE_API_KEY_SEP = re.compile(
+    r"\b(api[_-]?key|token|secret[_-]?key|bearer|authorization)[=:\s]+['\"]?([a-zA-Z0-9_-]{20,128})['\"]?",
+    re.IGNORECASE,
+)
+_RE_STANDALONE_KEY = re.compile(
+    r"(['\"])(sk-[a-zA-Z0-9_-]{20,128}|[a-zA-Z0-9_-]{30,128})(['\"])",
+)
+_RE_AUTH_HEADER = re.compile(
+    r"(Authorization:\s*)(Bearer\s+)?[a-zA-Z0-9_-]+",
+    re.IGNORECASE,
+)
+_RE_DICT_API_KEY = re.compile(
+    r'(["\']api[_-]?key["\']\s*:\s*["\'])([a-zA-Z0-9_-]{20,128})(["\'])',
+    re.IGNORECASE,
+)
+_RE_JWT = re.compile(
+    r"eyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]*",
+)
+_RE_URL_CRED = re.compile(
+    r"([?&](api[_-]?key|token|secret|access[_-]?token|auth)=)[a-zA-Z0-9_%-]{8,128}",
+    re.IGNORECASE,
+)
+_RE_FILE_PATH = re.compile(
+    r"(/(?:home|Users|tmp|var|etc|usr|opt|root)/[^\s:\"']+)",
+)
+
+
+def sanitize_error(error_msg: str) -> str:
+    """Sanitize error messages to remove API keys, file paths, and sensitive tokens.
+
+    Redacts common patterns:
+    - API keys (alphanumeric strings 20-128 chars)
+    - Bearer tokens
+    - Authorization headers
+    - Secret keys
+    - JWT tokens
+    - URL-embedded credentials
+    - Absolute file paths
+
+    Args:
+        error_msg: Original error message
+
+    Returns:
+        Sanitized error message with sensitive data redacted
+    """
+    # Redact API keys with = or : separators
+    sanitized = _RE_API_KEY_SEP.sub(r"\1=***REDACTED***", error_msg)
+
+    # Redact standalone API keys (sk-..., long alphanumeric strings in quotes)
+    sanitized = _RE_STANDALONE_KEY.sub(r"\1***REDACTED***\3", sanitized)
+
+    # Redact Authorization headers
+    sanitized = _RE_AUTH_HEADER.sub(r"\1***REDACTED***", sanitized)
+
+    # Redact dict-style API keys {"api_key": "value"}
+    sanitized = _RE_DICT_API_KEY.sub(r"\1***REDACTED***\3", sanitized)
+
+    # Redact JWT tokens
+    sanitized = _RE_JWT.sub("***REDACTED_JWT***", sanitized)
+
+    # Redact URL-embedded credentials
+    sanitized = _RE_URL_CRED.sub(r"\1***REDACTED***", sanitized)
+
+    # Redact absolute file paths
+    sanitized = _RE_FILE_PATH.sub("***REDACTED_PATH***", sanitized)
+
+    return sanitized


### PR DESCRIPTION
## Summary

10 fixes from two-layer review round 3. Plus reverts the over-constrained max_hops clamp from round 2.

## Fixes (19 files, 1 new)

1. **New `wikigr/utils.py`**: shared `sanitize_error()` utility for str(e) leaks
2. **5 str(e) leaks fixed**: build_pack_from_issue, rebuild_all_packs, check_pack_freshness, validate_pack_urls, loader.py
3. **ConnectionManager.close()**: now acquires lock (thread safety)
4. **_stream_executor**: registered shutdown in FastAPI lifespan
5. **config.yaml**: embedding model corrected (MiniLM → BGE)
6. **testpaths**: 6 directories added, 1 ghost entry removed (1766 tests now visible)
7. **Quickstart docs**: duplicate code block → actual context manager example
8. **Version strings**: all synced to 0.4.1
9. **edge_generator**: CREATE → MERGE (prevents duplicate edges)
10. **requirements.txt**: Python 3.10+ → 3.12+
11. **Revert max_hops**: library stays at 10 (API already caps at 3)

## Step 13: Local Testing Results

1. Full suite → **1766 passed**, 53 skipped ✅
2. Lint: ruff check → all passed ✅
3. Format: ruff format → all formatted ✅

Refs #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)