### PR TITLE
docs: clarify Skills as primary integration, MCP as alternative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- MCP server for GitHub Copilot and Claude Desktop integration (`mcp_server.py`)
-- Pack catalog generation script (`scripts/generate_catalog.py`)
-- Pack publishing script (`scripts/publish_packs.py`)
-- One-liner installation script (`scripts/install.sh`)
 - `CONTRIBUTING.md` with development guidelines
 - `LICENSE` file (MIT)
 - `CHANGELOG.md`
@@ -19,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Makefile` for common development tasks
 - Dockerfile (multi-stage: backend API and MCP server targets)
 - Shallow clone guidance in README for large repo
+- MCP server as alternative integration for GitHub Copilot and Claude Desktop (`mcp_server.py`)
+- Pack catalog generation script (`scripts/generate_catalog.py`)
+- Pack publishing script (`scripts/publish_packs.py`)
+- One-liner installation script (`scripts/install.sh`)
 
 ### Changed
 - UX overhaul for pack management workflows (#298)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,10 +108,11 @@ agent-kgpacks/
 ├── backend/           FastAPI REST API
 ├── frontend/          React UI
 ├── scripts/           Pack build and evaluation scripts
+├── skills/            /kg-pack skill definition (primary integration)
 ├── data/packs/        Knowledge pack databases and manifests
 ├── docs/              Documentation (MkDocs source)
 ├── tests/             Test suites
-└── mcp_server.py      Model Context Protocol server
+└── mcp_server.py      MCP server (alternative integration for Copilot/Claude Desktop)
 ```
 
 ## Reporting Issues

--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ Then in Claude Code:
 ```
 
 Each installed pack becomes its own Claude Code skill that auto-activates when
-you ask about that domain. See `skills/README.md` for details.
+you ask about that domain. Skills are the primary integration — see `skills/README.md` for details.
+
+> **Alternative integration**: An MCP server (`mcp_server.py`) is also available for GitHub Copilot and Claude Desktop, but Skills are the recommended approach for Claude Code.
 
 ## Pack Management (CLI)
 


### PR DESCRIPTION
## Summary

Clarifies that Skills are the primary way to use knowledge packs in Claude Code. MCP server is repositioned as an alternative integration for GitHub Copilot and Claude Desktop.

## Changes

- **README.md**: Added note below the `/kg-pack` commands clarifying Skills are recommended, MCP is alternative
- **CHANGELOG.md**: Reordered [Unreleased] entries so MCP is not the first item listed
- **CONTRIBUTING.md**: Labeled `skills/` as primary integration and `mcp_server.py` as alternative in project structure

## Step 13: Local Testing Results

**Test Environment**: fix/docs-skills-primary, 2026-03-08

1. Verified README reads clearly with Skills-first emphasis → ✅
2. Pre-commit hooks pass on all 3 changed files → ✅
3. No code changes — documentation only → ✅